### PR TITLE
feature/batch-analysis-start-at-phase: add --start-at merge operator lever

### DIFF
--- a/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
+++ b/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
@@ -58,6 +58,7 @@ interface GameReportClientProps {
   shortDesc?: string;
   reviewCount?: number;
   reviewCountEnglish?: number | null;
+  reviewCountAllLanguages?: number | null;
   deckCompatibility?: number | null;
   deckTestResults?: Array<{ display_type: number; loc_token: string }>;
   isEarlyAccess?: boolean;
@@ -70,7 +71,7 @@ interface GameReportClientProps {
   reviewsCompletedAt?: string | null;
   tagsCrawledAt?: string | null;
   lastAnalyzed?: string | null;
-  // Boxleiter v1 revenue estimate — surfaced by <MarketReach />
+  // Boxleiter v2 revenue estimate — surfaced by <MarketReach />
   estimatedOwners?: number | null;
   estimatedRevenueUsd?: number | null;
   revenueEstimateMethod?: string | null;
@@ -114,6 +115,7 @@ export function GameReportClient({
   shortDesc,
   reviewCount,
   reviewCountEnglish,
+  reviewCountAllLanguages,
   deckCompatibility,
   deckTestResults,
   isEarlyAccess,
@@ -281,6 +283,7 @@ export function GameReportClient({
         <QuickStats
           reviewCount={reviewCount ?? null}
           reviewCountEnglish={reviewCountEnglish ?? null}
+          reviewCountAllLanguages={reviewCountAllLanguages ?? null}
           totalReviewsAnalyzed={report?.total_reviews_analyzed ?? null}
           releaseDate={releaseDate}
           price={price}
@@ -292,7 +295,7 @@ export function GameReportClient({
           metaCrawledAt={metaCrawledAt}
         />
 
-        {/* Market Reach — Boxleiter v1 revenue estimate. Independent of the
+        {/* Market Reach — Boxleiter v2 revenue estimate. Independent of the
             LLM pass (review count + price + genre/tags is enough), so it
             renders on unanalyzed pages too. */}
         <MarketReach
@@ -300,7 +303,8 @@ export function GameReportClient({
           estimatedRevenueUsd={estimatedRevenueUsd ?? null}
           method={revenueEstimateMethod ?? null}
           reason={revenueEstimateReason ?? null}
-          reviewCount={reviewCount ?? 0}
+          reviewCount={reviewCountAllLanguages ?? reviewCount ?? 0}
+          reviewCountEnglish={reviewCountEnglish ?? null}
         />
 
         {/* About — only shown on unanalyzed pages. On analyzed pages the

--- a/frontend/app/games/[appid]/[slug]/page.tsx
+++ b/frontend/app/games/[appid]/[slug]/page.tsx
@@ -99,6 +99,7 @@ export default async function GameReportPage({ params }: Props) {
     shortDesc?: string;
     reviewCount?: number;
     reviewCountEnglish?: number | null;
+    reviewCountAllLanguages?: number | null;
     deckCompatibility?: number | null;
     deckTestResults?: Array<{ display_type: number; loc_token: string }>;
     isEarlyAccess?: boolean;
@@ -142,18 +143,21 @@ export default async function GameReportPage({ params }: Props) {
       // Always prefer review_count_english so the number next to positive_pct /
       // review_score_desc stays on the same English-implicit basis; fall back
       // to all-language review_count only when no English count exists (keeps
-      // QuickStats' Reviews tile and MarketReach's X/50 empty state populated).
+      // QuickStats' Reviews tile and MarketReach's X/500 empty state populated).
+      // reviewCountAllLanguages carries the raw all-language total — MarketReach
+      // compares against it to surface "Based on N reviews (all languages)".
       if (g.positive_pct != null) gameData.positivePct = g.positive_pct;
       if (g.review_score_desc != null) gameData.reviewScoreDesc = g.review_score_desc;
       const englishAlignedCount = g.review_count_english ?? g.review_count;
       if (englishAlignedCount != null) gameData.reviewCount = englishAlignedCount;
       if (g.review_count_english != null) gameData.reviewCountEnglish = g.review_count_english;
+      if (g.review_count != null) gameData.reviewCountAllLanguages = g.review_count;
       if (g.meta_crawled_at) gameData.metaCrawledAt = g.meta_crawled_at;
       if (g.review_crawled_at) gameData.reviewCrawledAt = g.review_crawled_at;
       if (g.reviews_completed_at) gameData.reviewsCompletedAt = g.reviews_completed_at;
       if (g.tags_crawled_at) gameData.tagsCrawledAt = g.tags_crawled_at;
       if (g.last_analyzed) gameData.lastAnalyzed = g.last_analyzed;
-      // Boxleiter v1 revenue estimate fields — forwarded to <MarketReach />
+      // Boxleiter v2 revenue estimate fields — forwarded to <MarketReach />
       if (g.estimated_owners != null) gameData.estimatedOwners = g.estimated_owners;
       if (g.estimated_revenue_usd != null) gameData.estimatedRevenueUsd = g.estimated_revenue_usd;
       if (g.revenue_estimate_method) gameData.revenueEstimateMethod = g.revenue_estimate_method;
@@ -328,6 +332,7 @@ export default async function GameReportPage({ params }: Props) {
           shortDesc={gameData.shortDesc}
           reviewCount={gameData.reviewCount}
           reviewCountEnglish={gameData.reviewCountEnglish}
+          reviewCountAllLanguages={gameData.reviewCountAllLanguages}
           deckCompatibility={gameData.deckCompatibility}
           deckTestResults={gameData.deckTestResults}
           isEarlyAccess={gameData.isEarlyAccess}

--- a/frontend/components/game/MarketReach.tsx
+++ b/frontend/components/game/MarketReach.tsx
@@ -9,13 +9,19 @@ interface MarketReachProps {
   method: string | null;
   // "insufficient_reviews" | "free_to_play" | "missing_price" | "excluded_type" | null
   reason: string | null;
+  // All-language review count — what the estimator actually consumed.
   reviewCount: number;
+  // English-only count, used to decide whether to surface the "all languages"
+  // basis line (only when it diverges from the all-language total).
+  reviewCountEnglish: number | null;
 }
 
-// ±50% confidence band — matches the documented Boxleiter v1 precision.
-// We display a single point estimate (less noisy, easier to compare across
-// games) and surface the full range as a hover tooltip for power users.
-const CONFIDENCE = 0.5;
+// Confidence band widens in the small-sample zone where calibration data is thin.
+function confidenceFor(reviewCount: number): number {
+  if (reviewCount >= 50_000) return 0.4;
+  if (reviewCount >= 5_000) return 0.6;
+  return 1.0;
+}
 
 /** Round to 2 significant figures so the displayed value reads as honest
  * ("480M") rather than fake-precise ("483,127,914"). */
@@ -46,7 +52,7 @@ function formatRevenue(n: number): string {
 function emptyStateCopy(reason: string | null, reviewCount: number): string {
   switch (reason) {
     case "insufficient_reviews":
-      return `Not enough reviews yet to estimate (${reviewCount}/50).`;
+      return `Not enough reviews yet to estimate (${reviewCount.toLocaleString()}/500).`;
     case "free_to_play":
       return "Free-to-play — revenue estimates don't apply.";
     case "missing_price":
@@ -58,7 +64,7 @@ function emptyStateCopy(reason: string | null, reviewCount: number): string {
   }
 }
 
-function ConfidencePill() {
+function ConfidencePill({ confidence }: { confidence: number }) {
   return (
     <span
       className="text-[10px] font-mono uppercase tracking-widest px-1.5 py-0.5 rounded"
@@ -68,7 +74,23 @@ function ConfidencePill() {
         border: "1px solid var(--border)",
       }}
     >
-      ±50%
+      ±{Math.round(confidence * 100)}%
+    </span>
+  );
+}
+
+function SmallSamplePill() {
+  return (
+    <span
+      className="text-[10px] font-mono uppercase tracking-widest px-1.5 py-0.5 rounded"
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        color: "var(--muted-foreground)",
+        border: "1px dashed var(--border)",
+      }}
+      title="Calibration data is thin below 5,000 reviews — treat as a rough directional read."
+    >
+      Small-sample
     </span>
   );
 }
@@ -94,23 +116,29 @@ function Stat({
   label,
   value,
   formatter,
+  confidence,
+  showSmallSample,
 }: {
   label: string;
   value: number;
   formatter: (n: number) => string;
+  confidence: number;
+  showSmallSample: boolean;
 }) {
   const point = roundToSigFigs(value);
-  const low = roundToSigFigs(value * (1 - CONFIDENCE));
-  const high = roundToSigFigs(value * (1 + CONFIDENCE));
-  const rangeTooltip = `Range: ${formatter(low)} – ${formatter(high)} (±50%)`;
+  const low = roundToSigFigs(value * (1 - confidence));
+  const high = roundToSigFigs(value * (1 + confidence));
+  const pctLabel = `±${Math.round(confidence * 100)}%`;
+  const rangeTooltip = `Range: ${formatter(low)} – ${formatter(high)} (${pctLabel})`;
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-1">
+      <div className="flex items-center gap-2 mb-1 flex-wrap">
         <span className="text-xs uppercase tracking-widest font-mono text-muted-foreground">
           {label}
         </span>
-        <ConfidencePill />
+        <ConfidencePill confidence={confidence} />
+        {showSmallSample && <SmallSamplePill />}
       </div>
       <p className="font-mono text-lg font-medium" title={rangeTooltip}>
         <span className="text-muted-foreground mr-0.5">≈</span>
@@ -126,8 +154,13 @@ export function MarketReach({
   method,
   reason,
   reviewCount,
+  reviewCountEnglish,
 }: MarketReachProps) {
   const hasEstimate = estimatedOwners != null && estimatedRevenueUsd != null;
+  const confidence = confidenceFor(reviewCount);
+  const showSmallSample = reviewCount < 5_000;
+  const showBasisLine =
+    reviewCountEnglish != null && reviewCountEnglish !== reviewCount;
 
   return (
     <section className="animate-fade-up" data-testid="market-reach">
@@ -150,13 +183,25 @@ export function MarketReach({
                 label="Estimated owners"
                 value={estimatedOwners!}
                 formatter={formatOwners}
+                confidence={confidence}
+                showSmallSample={showSmallSample}
               />
               <Stat
                 label="Estimated gross revenue"
                 value={estimatedRevenueUsd!}
                 formatter={formatRevenue}
+                confidence={confidence}
+                showSmallSample={showSmallSample}
               />
             </div>
+            {showBasisLine && (
+              <p
+                className="mt-2 text-xs text-muted-foreground font-mono"
+                data-testid="market-reach-basis"
+              >
+                Based on {reviewCount.toLocaleString()} reviews (all languages)
+              </p>
+            )}
             <div className="mt-4 flex items-center gap-3 flex-wrap">
               {method && <MethodPill method={method} />}
               <p className="text-xs text-muted-foreground leading-relaxed">

--- a/frontend/components/game/QuickStats.tsx
+++ b/frontend/components/game/QuickStats.tsx
@@ -9,12 +9,16 @@ interface QuickStatsProps {
   /** English-preferred review count (`review_count_english ?? review_count`).
    *  Used as the Reviews tile's main value only when `reviewCountEnglish` is
    *  null — in that case the "en" suffix is suppressed because the fallback
-   *  may be the all-language total. Also feeds MarketReach and the JSON-LD
-   *  aggregateRating count, so its semantics must stay stable. */
+   *  may be the all-language total. Also feeds the JSON-LD aggregateRating
+   *  count, so its semantics must stay stable. */
   reviewCount: number | null;
   /** Steam's English-only review count from game metadata. Takes precedence
    *  over `reviewCount` as the main value and drives the "en" suffix. */
   reviewCountEnglish: number | null;
+  /** Raw all-language review count from game metadata. Drives the
+   *  "N total (all languages)" subline — rendered only when it diverges
+   *  from the English count. */
+  reviewCountAllLanguages: number | null;
   /** Count of reviews our pipeline ingested. Rendered only as the
    *  "N analyzed" subtitle — never as the main tile value. */
   totalReviewsAnalyzed: number | null;
@@ -51,6 +55,7 @@ const TILE_STYLE = {
 export function QuickStats({
   reviewCount,
   reviewCountEnglish,
+  reviewCountAllLanguages,
   totalReviewsAnalyzed,
   releaseDate,
   price,
@@ -64,6 +69,10 @@ export function QuickStats({
   const reviewsValue = reviewCountEnglish ?? reviewCount;
   const showEnSuffix = reviewCountEnglish != null;
   const showAnalyzedSuffix = totalReviewsAnalyzed != null;
+  const showAllLangSuffix =
+    reviewCountEnglish != null &&
+    reviewCountAllLanguages != null &&
+    reviewCountAllLanguages !== reviewCountEnglish;
   const reviewsTs = formatDate(reviewCrawledAt ?? reviewsCompletedAt);
   const metaTs = formatDate(metaCrawledAt);
   // Tiles: Reviews + Released + Price + Velocity = 4 base, +1 when analyzed.
@@ -94,6 +103,14 @@ export function QuickStats({
               </span>
             )}
           </p>
+          {showAllLangSuffix && (
+            <p
+              data-testid="reviews-tile-all-lang"
+              className="text-xs font-mono text-muted-foreground mt-1"
+            >
+              {reviewCountAllLanguages!.toLocaleString()} total (all languages)
+            </p>
+          )}
           {showAnalyzedSuffix && (
             <p className="text-xs font-mono text-muted-foreground mt-1">
               {totalReviewsAnalyzed!.toLocaleString()} analyzed

--- a/infra/stacks/batch_analysis_stack.py
+++ b/infra/stacks/batch_analysis_stack.py
@@ -10,7 +10,10 @@ Resources:
   - IAM role assumed by Bedrock to read/write S3
   - 3 Lambdas: PreparePhase, CollectPhase, CheckBatchStatus
   - STANDARD Step Functions state machine (wait/choice loops per phase)
-  - EventBridge rule (disabled by default — for future scheduled re-analysis)
+
+Batch analysis is triggered ONLY by a human operator running
+``scripts/trigger_batch_analysis.py`` — no scheduled rules, event
+sources, or automated dispatch Lambdas are wired into this stack.
 """
 
 import aws_cdk as cdk

--- a/infra/stacks/batch_analysis_stack.py
+++ b/infra/stacks/batch_analysis_stack.py
@@ -395,11 +395,17 @@ class BatchAnalysisStack(cdk.Stack):
         merge_l1_chain = _merge_level_chain("", 1, merge_needs_l2)
         chunk_chain = _phase_chain("chunk", merge_l1_chain)
 
+        start_choice = sfn.Choice(self, "StartAtChoice")
+        start_choice.when(
+            sfn.Condition.string_equals("$.start_at", "merge"),
+            merge_l1_chain,
+        ).otherwise(chunk_chain)
+
         state_machine = sfn.StateMachine(
             self,
             "BatchAnalysisMachine",
             state_machine_name=f"steampulse-batch-analysis-{env}",
-            definition_body=sfn.DefinitionBody.from_chainable(chunk_chain),
+            definition_body=sfn.DefinitionBody.from_chainable(start_choice),
             state_machine_type=sfn.StateMachineType.STANDARD,
             logs=sfn.LogOptions(
                 destination=logs.LogGroup(
@@ -503,7 +509,10 @@ class BatchAnalysisStack(cdk.Stack):
                 "RunPerGame",
                 state_machine=state_machine,
                 integration_pattern=sfn.IntegrationPattern.RUN_JOB,
-                input=sfn.TaskInput.from_object({"appid": sfn.JsonPath.number_at("$")}),
+                input=sfn.TaskInput.from_object({
+                    "appid": sfn.JsonPath.number_at("$"),
+                    "start_at": sfn.JsonPath.string_at("$$.Execution.Input.start_at"),
+                }),
             )
         )
 

--- a/scripts/backfill_revenue_estimates.py
+++ b/scripts/backfill_revenue_estimates.py
@@ -1,4 +1,4 @@
-"""Backfill Boxleiter v1 revenue estimates for existing games.
+"""Backfill Boxleiter v2 revenue estimates for existing games.
 
 Pure-Python: no LLM calls, no Steam API, no reviews crawled. Reads games,
 genres, and tags straight from the DB and calls `compute_estimate` for each
@@ -29,6 +29,7 @@ surfaces pick up the new values:
     REFRESH MATERIALIZED VIEW CONCURRENTLY mv_genre_games;
     REFRESH MATERIALIZED VIEW CONCURRENTLY mv_tag_games;
     REFRESH MATERIALIZED VIEW CONCURRENTLY mv_price_positioning;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY mv_discovery_feeds;
 """
 
 from __future__ import annotations
@@ -110,7 +111,7 @@ def _fetch_games_bulk(game_repo: GameRepository, appids: list[int]) -> dict[int,
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Backfill Boxleiter v1 revenue estimates.")
+    parser = argparse.ArgumentParser(description="Backfill Boxleiter v2 revenue estimates.")
     parser.add_argument("--dry-run", action="store_true", help="Compute but do not write.")
     parser.add_argument(
         "--all",
@@ -230,6 +231,7 @@ def main() -> None:
         print("  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_genre_games;")
         print("  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_tag_games;")
         print("  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_price_positioning;")
+        print("  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_discovery_feeds;")
 
 
 if __name__ == "__main__":

--- a/scripts/prompts/batch-analysis-start-at-phase.md
+++ b/scripts/prompts/batch-analysis-start-at-phase.md
@@ -1,0 +1,277 @@
+# Operator lever: `--start-at <phase>` for batch analysis
+
+## Context
+
+A handful of per-game analyses fail because one chunk out of N fails
+pydantic validation at the collect phase. The game's other chunks
+(e.g. 11 of 12) are already persisted to `chunk_summaries` with a
+valid schema. Today the only way forward is to keep re-rolling the
+missing chunk until the LLM happens to comply — at ~$0.10 per
+re-roll with a non-trivial miss rate, for a single game that's
+annoying; across a wedge run it gets expensive.
+
+Example: appid `1184820` (Poker Quest). 11 of 12 chunks persisted
+under `chunk-v2.0`. Chunk 0 (50 reviews, hash
+`2a1cf5f61f7f50c4`) keeps failing on `topics.N.sentiment =
+'neutral'` — the model emits a neutral-valence topic despite the
+prompt's explicit omit-instead-of-neutral rule, and our strict
+enum rejects it. Every retry resubmits the same 50 reviews to the
+backend and gambles on model compliance.
+
+What we actually want here is an **operator lever** — when the
+state machine fails at the chunk phase on 1 of 12 chunks, let the
+operator advance the game manually, using whatever is already
+persisted. The merge phase reads cached chunks via
+`chunk_repo.find_by_appid(appid, CHUNK_PROMPT_VERSION)`, so 11
+chunks is the corpus the merge sees — and the report it produces
+honestly reflects the 11-chunk corpus (e.g. ~550 of 561 reviews).
+
+## Scope (this prompt)
+
+Add a `--start-at <phase>` flag to `scripts/trigger_batch_analysis.py`
+that, when set to `merge`, causes the per-game state machine to
+skip the chunk phase and begin at `PrepareMerge`. Synthesize from
+the already-persisted chunks.
+
+**In scope for this prompt:**
+- `--start-at chunk` (default; today's behavior)
+- `--start-at merge` (skip chunk phase, start at merge L1 prepare)
+
+**Deferred (NOT this prompt):** `--start-at synthesis` — would
+require threading `merged_summary_id` through the input, and the
+per-game machine has a race-condition comment at
+`batch_analysis_stack.py:206-214` explicitly warning against any
+"non-deterministic (appid, latest)" lookup for the merge row.
+Doing synthesis-start right is its own prompt. For now: enum
+restricted to `{chunk, merge}`; raise `argparse.ArgumentTypeError`
+if anything else is passed.
+
+## What to do
+
+### 1. `scripts/trigger_batch_analysis.py`
+
+Add:
+
+```python
+parser.add_argument(
+    "--start-at",
+    choices=["chunk", "merge"],
+    default="chunk",
+    help="Phase to start at. 'merge' skips chunk phase — the "
+         "per-game machine reads cached chunks from chunk_summaries "
+         "and begins at PrepareMerge. Use when chunks are already "
+         "persisted (e.g. a prior run failed on one chunk). Default: chunk.",
+)
+```
+
+Include `start_at` in the execution input payload:
+
+```python
+payload = {
+    "appids": args.appids,
+    "max_concurrency": args.concurrency,
+    "start_at": args.start_at,
+}
+```
+
+Print `start_at` in the summary line after submission so the
+operator sees it echoed back.
+
+### 2. Orchestrator — thread `start_at` through the DistributedMap
+
+In `infra/stacks/batch_analysis_stack.py` at the `RunPerGame` task
+inside `fan_out.item_processor` (~line 500-508), change the input
+to also carry `start_at` from the orchestrator execution input:
+
+```python
+input=sfn.TaskInput.from_object({
+    "appid": sfn.JsonPath.number_at("$"),
+    "start_at": sfn.JsonPath.string_at("$$.Execution.Input.start_at"),
+}),
+```
+
+`$$.Execution.Input.start_at` reaches back to the orchestrator's
+input payload. The DistributedMap's per-item context (`$`) is the
+current appid only.
+
+If the orchestrator is invoked without `start_at` in its input
+(e.g. via the matview-scheduled dispatch path at
+`batch_analysis_stack.py:424+`), this JSONPath reference will
+raise. Guard one of two ways — pick whichever is cleaner in this
+codebase:
+
+- **Option A** (preferred): update the dispatch Lambda and any
+  other programmatic callers to always include `start_at: "chunk"`
+  in their input.
+- **Option B**: use `States.JsonToString` + a default in a
+  Pass state. Heavier.
+
+### 3. Per-game AnalysisMachine — branch on `start_at`
+
+In `infra/stacks/batch_analysis_stack.py`, the machine is currently
+built as:
+
+```python
+merge_l1_chain = _merge_level_chain("", 1, merge_needs_l2)
+chunk_chain = _phase_chain("chunk", merge_l1_chain)
+state_machine = sfn.StateMachine(..., definition_body=sfn.DefinitionBody.from_chainable(chunk_chain), ...)
+```
+
+Insert a Choice state as the new entry point BEFORE
+`state_machine` is constructed:
+
+```python
+start_choice = sfn.Choice(self, "StartAtChoice")
+start_choice.when(
+    sfn.Condition.string_equals("$.start_at", "merge"),
+    merge_l1_chain,
+).otherwise(chunk_chain)
+
+state_machine = sfn.StateMachine(
+    ...,
+    definition_body=sfn.DefinitionBody.from_chainable(start_choice),
+    ...
+)
+```
+
+The merge-start branch requires no other state-machine change —
+`_merge_level_chain("")` begins at `PrepareMerge` which calls the
+prepare Lambda with `phase="merge"`, and the prepare Lambda
+already does `chunk_repo.find_by_appid(appid, CHUNK_PROMPT_VERSION)`
+to build the merge batch. It naturally works on 11 chunks or 40
+chunks — whatever is there.
+
+### 4. Minimum-chunks floor in `run_merge_phase`
+
+Today `run_merge_phase` in `analyzer.py:1012` raises only for zero
+chunks. Anything ≥1 is allowed through. With the new lever,
+operators can now start merge against whatever is cached — so we
+need a **hard floor** below which cross-chunk synthesis becomes
+statistically unreliable.
+
+Pick `5 chunks` (= 250 reviews at the default 50-review chunk
+size). Rationale:
+
+- **Statistical cover:** the genre synthesizer's
+  `SHARED_SIGNAL_MIN_MENTIONS = 3` means a "recurring signal"
+  needs to appear in 60% of chunks at 5-chunk corpora. Below 5,
+  any single chunk's opinion dominates — the "cross-chunk merge"
+  stops being cross-chunk.
+- **Anchored to wedge eligibility:** the wedge restricts games to
+  ≥500 reviews, implying ~10 chunks per fully-analyzed game. 5 is
+  half that — the obvious "something's broken, don't synthesize"
+  line.
+- **Doesn't trip the real use case:** 11-of-12 chunks (appid
+  `1184820`) and 17-of-18 chunks (typical partial case) pass
+  comfortably. 5 only catches pathological states (operator typo,
+  stale partial set, future soft-threshold misconfig).
+
+Extend the existing zero-check:
+
+```python
+MIN_CHUNKS_FOR_MERGE = 5  # Hard floor below which cross-chunk
+                          # signal becomes noise. Anchored to the
+                          # wedge's ≥500-review / ~10-chunk implied
+                          # minimum.
+
+if len(chunks) < MIN_CHUNKS_FOR_MERGE:
+    raise ValueError(
+        f"run_merge_phase requires at least {MIN_CHUNKS_FOR_MERGE} "
+        f"chunks (got {len(chunks)} for appid={appid}). Below this "
+        f"floor, cross-chunk topic synthesis is statistically "
+        f"unreliable. If this is a start_at=merge run, verify "
+        f"chunk_summaries has the expected rows for this appid."
+    )
+```
+
+The single guard covers both paths: `--start-at merge` with zero
+or too-few cached chunks, AND any future automated soft-threshold
+flow that lets chunk phase proceed with partial success. No
+separate `start_at=="merge"` branch needed — the floor is
+universal.
+
+Constant lives in `analyzer.py` next to `CHUNK_PROMPT_VERSION`
+(module-level). Don't promote to `SteamPulseConfig` yet; it's an
+invariant, not a tuning knob.
+
+## Verification
+
+1. **Unit + lint locally:**
+   ```
+   poetry run pytest -v tests/
+   poetry run ruff check .
+   ```
+
+2. **Dry-run the trigger script:**
+   ```
+   poetry run python scripts/trigger_batch_analysis.py \
+       --env staging --start-at merge --appids 1184820 --dry-run
+   ```
+   Payload in the "would-send" output should include
+   `"start_at": "merge"`.
+
+3. **CDK diff:** `cdk diff --app "python app.py"` for the
+   BatchAnalysis stack. Expect: new `StartAtChoice` Choice state +
+   modified `RunPerGame` task input. No Lambda code signature
+   changes.
+
+4. **Staging smoke test — default path:**
+   ```
+   poetry run python scripts/trigger_batch_analysis.py \
+       --env staging --appids <a staging appid with no reports>
+   ```
+   (No `--start-at`, so it defaults to `chunk`.) Expect: standard
+   chunk → merge → synthesis flow. Existing behavior preserved.
+
+5. **Staging smoke test — merge-start path:**
+   - Pick a staging appid that has a FULL set of chunks under
+     `chunk-v2.0` but no report (or delete the report to redo it).
+   - Run: `--start-at merge --appids <that appid>`.
+   - Expected: execution skips chunk, starts at `PrepareMerge`,
+     succeeds through merge and synthesis.
+   - Check Step Functions execution history — first state entered
+     should be `StartAtChoice`, immediate transition to
+     `PrepareMerge`.
+
+6. **Staging smoke test — minimum-chunks floor:**
+   - Pick (or set up) a staging appid with fewer than 5 chunks in
+     `chunk_summaries` (e.g. DELETE all but 3 chunks for a test
+     appid).
+   - Run: `--start-at merge --appids <that appid>`.
+   - Expected: merge prepare fails with a clean ValueError citing
+     `MIN_CHUNKS_FOR_MERGE = 5` and the actual chunk count.
+     Execution transitions from `PrepareMerge` to `PhaseFailed`
+     without submitting a batch request to the backend (no money
+     spent).
+
+6. **Production cutover — the actual use case:**
+   ```
+   poetry run python scripts/trigger_batch_analysis.py \
+       --env production --start-at merge --appids 1184820 3205380
+   ```
+   Expected: both games produce reports using their existing
+   cached chunks (11 of 12 for 1184820, 18-of-whatever for 3205380).
+
+## Rollout
+
+- Single deploy. Default `--start-at chunk` preserves all existing
+  automated and manual flows.
+- The user runs `bash scripts/deploy.sh` — do not deploy from
+  Claude.
+- After deploy, use the new flag on the two stuck appids per the
+  command above.
+
+## Out of scope
+
+- `--start-at synthesis`. Adds complexity around
+  `merged_summary_id` plumbing and intersects with the
+  race-condition commentary at `batch_analysis_stack.py:204-214`.
+  Separate prompt when/if needed.
+- Per-topic drop-instead-of-fail (previous proposal). Covered by
+  this lever for the current case; revisit only if the chunk-phase
+  compliance miss rate becomes a systemic cost issue.
+- Soft chunk-failure threshold (`CHUNK_PHASE_MIN_PERSIST_RATIO`)
+  inside the chunk collect phase. Still a separate lever — this
+  prompt gives operators a manual escape hatch; the soft threshold
+  would be an automated policy. Both can coexist later.
+- Changing `CHUNK_PROMPT_VERSION` or any model schemas.

--- a/scripts/prompts/batch-analysis-start-at-phase.md
+++ b/scripts/prompts/batch-analysis-start-at-phase.md
@@ -240,11 +240,12 @@ invariant, not a tuning knob.
    - Run: `--start-at merge --appids <that appid>`.
    - Expected: merge prepare fails with a clean ValueError citing
      `MIN_CHUNKS_FOR_MERGE = 5` and the actual chunk count.
-     Execution transitions from `PrepareMerge` to `PhaseFailed`
-     without submitting a batch request to the backend (no money
-     spent).
+     The per-game execution fails on the `PrepareMerge` task
+     itself (that is, no transition to `PhaseFailed` unless the
+     SFN is updated to add a `Catch` there), and no batch request
+     is submitted to the backend (no money spent).
 
-6. **Production cutover — the actual use case:**
+7. **Production cutover — the actual use case:**
    ```
    poetry run python scripts/trigger_batch_analysis.py \
        --env production --start-at merge --appids 1184820 3205380

--- a/scripts/prompts/batch-analysis-start-at-phase.md
+++ b/scripts/prompts/batch-analysis-start-at-phase.md
@@ -37,6 +37,26 @@ the already-persisted chunks.
 - `--start-at chunk` (default; today's behavior)
 - `--start-at merge` (skip chunk phase, start at merge L1 prepare)
 
+**Also shipped in this PR (scope-adjacent hardening, 2026-04-23):**
+Disable every automatic batch-analysis dispatch path. Batch analysis
+must run ONLY when a human invokes
+`scripts/trigger_batch_analysis.py` (or `sp.py batch <appids>`, which
+is the same path — it calls `start_execution` directly on the
+orchestrator SFN, not the dispatch Lambda). The matview-driven
+`_handle_dispatch` branch in the dispatch Lambda is commented out and
+its code path now raises a clear `RuntimeError` if invoked. The
+`sp.py dispatch` subcommand and its helpers are likewise commented
+out. Kept as comments (not deleted) so we can re-enable auto-dispatch
+later if we ever want scheduled analysis again. Sweep confirmed: no
+EventBridge rule, SQS event source, or other automated trigger was
+ever wired to `DispatchBatchFn` — the only remaining invocation is
+the orchestrator's own `PublishBatchAnalysisComplete` step, which
+uses `action="post_batch"` to publish the batch-complete event and
+never starts a new execution. A stale line in the
+`batch_analysis_stack.py` docstring referring to an "EventBridge rule
+(disabled by default)" is removed (no such rule was ever present in
+code).
+
 **Deferred (NOT this prompt):** `--start-at synthesis` — would
 require threading `merged_summary_id` through the input, and the
 per-game machine has a race-condition comment at

--- a/scripts/sp.py
+++ b/scripts/sp.py
@@ -574,12 +574,15 @@ def _ready_for_analysis(n: int = 1000) -> list[int]:
         return [row[0] for row in cur.fetchall()]
 
 
-def _resolve_dispatch_fn_name(env: str) -> str:
-    """Resolve the dispatch Lambda function name from SSM."""
-    import boto3
-
-    ssm = boto3.client("ssm", region_name="us-west-2")
-    return ssm.get_parameter(Name=f"/steampulse/{env}/batch/dispatch-fn-name")["Parameter"]["Value"]
+# Auto-dispatch disabled — the matview-driven dispatch Lambda path is off.
+# Batch analysis runs only via `scripts/trigger_batch_analysis.py` (or
+# `sp.py batch <appids>`). Kept as comments in case we re-enable it later.
+# def _resolve_dispatch_fn_name(env: str) -> str:
+#     """Resolve the dispatch Lambda function name from SSM."""
+#     import boto3
+#
+#     ssm = boto3.client("ssm", region_name="us-west-2")
+#     return ssm.get_parameter(Name=f"/steampulse/{env}/batch/dispatch-fn-name")["Parameter"]["Value"]
 
 
 # ── subcommand implementations ────────────────────────────────────────────────
@@ -798,59 +801,60 @@ def cmd_batch(
         _info("Stopped watching (execution still running)")
 
 
-def cmd_dispatch(
-    batch_size: int | None,
-    dry_run: bool,
-    watch: bool,
-    env: str,
-) -> None:
-    """Invoke the deployed dispatch Lambda to start the next batch."""
-    fn_name = _resolve_dispatch_fn_name(env)
-    payload: dict[str, object] = {"dry_run": dry_run}
-    if batch_size is not None:
-        payload["batch_size"] = batch_size
-
-    _info(f"Invoking {fn_name} (batch_size={batch_size or 'default'}, dry_run={dry_run})")
-    result = _invoke_lambda(fn_name, payload)
-
-    dispatched = result.get("dispatched", 0)
-    appids = result.get("appids", [])
-
-    if not appids:
-        _warn("No candidates — matview is empty or fully analyzed")
-        return
-
-    if dry_run:
-        for i, appid in enumerate(appids, 1):
-            _info(f"  {i:>4}. {appid}")
-        _warn(f"[dry-run] Would dispatch {dispatched} games to orchestrator")
-        return
-
-    execution_arn = result.get("execution_arn", "")
-    _ok(f"Dispatched {dispatched} games")
-    _info(f"  Execution ARN: {execution_arn}")
-
-    if not watch or not execution_arn:
-        return
-
-    import boto3
-
-    sfn = boto3.client("stepfunctions")
-    _info("Watching (Ctrl+C to stop)...")
-    try:
-        while True:
-            time.sleep(30)
-            desc = sfn.describe_execution(executionArn=execution_arn)
-            status = desc["status"]
-            _info(f"  [{time.strftime('%H:%M:%S')}] {status}")
-            if status in ("SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"):
-                if status == "SUCCEEDED":
-                    _ok("Execution succeeded")
-                else:
-                    _err(f"Execution {status.lower()}")
-                break
-    except KeyboardInterrupt:
-        _info("Stopped watching (execution still running)")
+# Auto-dispatch disabled — see note on _resolve_dispatch_fn_name above.
+# def cmd_dispatch(
+#     batch_size: int | None,
+#     dry_run: bool,
+#     watch: bool,
+#     env: str,
+# ) -> None:
+#     """Invoke the deployed dispatch Lambda to start the next batch."""
+#     fn_name = _resolve_dispatch_fn_name(env)
+#     payload: dict[str, object] = {"dry_run": dry_run}
+#     if batch_size is not None:
+#         payload["batch_size"] = batch_size
+#
+#     _info(f"Invoking {fn_name} (batch_size={batch_size or 'default'}, dry_run={dry_run})")
+#     result = _invoke_lambda(fn_name, payload)
+#
+#     dispatched = result.get("dispatched", 0)
+#     appids = result.get("appids", [])
+#
+#     if not appids:
+#         _warn("No candidates — matview is empty or fully analyzed")
+#         return
+#
+#     if dry_run:
+#         for i, appid in enumerate(appids, 1):
+#             _info(f"  {i:>4}. {appid}")
+#         _warn(f"[dry-run] Would dispatch {dispatched} games to orchestrator")
+#         return
+#
+#     execution_arn = result.get("execution_arn", "")
+#     _ok(f"Dispatched {dispatched} games")
+#     _info(f"  Execution ARN: {execution_arn}")
+#
+#     if not watch or not execution_arn:
+#         return
+#
+#     import boto3
+#
+#     sfn = boto3.client("stepfunctions")
+#     _info("Watching (Ctrl+C to stop)...")
+#     try:
+#         while True:
+#             time.sleep(30)
+#             desc = sfn.describe_execution(executionArn=execution_arn)
+#             status = desc["status"]
+#             _info(f"  [{time.strftime('%H:%M:%S')}] {status}")
+#             if status in ("SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"):
+#                 if status == "SUCCEEDED":
+#                     _ok("Execution succeeded")
+#                 else:
+#                     _err(f"Execution {status.lower()}")
+#                 break
+#     except KeyboardInterrupt:
+#         _info("Stopped watching (execution still running)")
 
 
 # ── matview-refresh (start the Step Functions state machine) ─────────────────
@@ -1206,31 +1210,31 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Poll execution status every 30s until complete (Ctrl+C to stop)",
     )
 
-    # ── dispatch (read matview → start orchestrator)
-    di = sub.add_parser("dispatch", help="Dispatch next batch from analysis candidate list")
-    di.add_argument(
-        "--env",
-        default="staging",
-        choices=["staging", "production"],
-        help="Environment (default: staging)",
-    )
-    di.add_argument(
-        "--batch-size",
-        type=int,
-        default=None,
-        metavar="N",
-        help="Number of games to dispatch (omit to use the deployed default)",
-    )
-    di.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show candidates without starting an execution",
-    )
-    di.add_argument(
-        "--watch",
-        action="store_true",
-        help="Poll execution status every 30s until complete (Ctrl+C to stop)",
-    )
+    # ── dispatch subcommand removed — auto-dispatch is disabled; use `sp.py batch` instead.
+    # di = sub.add_parser("dispatch", help="Dispatch next batch from analysis candidate list")
+    # di.add_argument(
+    #     "--env",
+    #     default="staging",
+    #     choices=["staging", "production"],
+    #     help="Environment (default: staging)",
+    # )
+    # di.add_argument(
+    #     "--batch-size",
+    #     type=int,
+    #     default=None,
+    #     metavar="N",
+    #     help="Number of games to dispatch (omit to use the deployed default)",
+    # )
+    # di.add_argument(
+    #     "--dry-run",
+    #     action="store_true",
+    #     help="Show candidates without starting an execution",
+    # )
+    # di.add_argument(
+    #     "--watch",
+    #     action="store_true",
+    #     help="Poll execution status every 30s until complete (Ctrl+C to stop)",
+    # )
 
     # ── matview-refresh (start the SFN directly)
     mr = sub.add_parser(
@@ -1401,8 +1405,8 @@ def main() -> None:
     elif args.cmd == "batch":
         cmd_batch(args.appids, args.concurrency, args.dry_run, args.watch, args.env)
 
-    elif args.cmd == "dispatch":
-        cmd_dispatch(args.batch_size, args.dry_run, args.watch, args.env)
+    # elif args.cmd == "dispatch":
+    #     cmd_dispatch(args.batch_size, args.dry_run, args.watch, args.env)
 
     elif args.cmd == "matview-refresh":
         cmd_matview_refresh(args.env, args.force)

--- a/scripts/sp.py
+++ b/scripts/sp.py
@@ -745,7 +745,7 @@ def cmd_batch(
     """Start a batch analysis orchestrator execution (fan-out over appids)."""
     import boto3
 
-    payload = {"appids": appids, "max_concurrency": concurrency}
+    payload = {"appids": appids, "max_concurrency": concurrency, "start_at": "chunk"}
 
     _info(f"Batch analysis → {env}")
     _info(f"  Appids:      {len(appids)}: {appids}")

--- a/scripts/trigger_batch_analysis.py
+++ b/scripts/trigger_batch_analysis.py
@@ -30,6 +30,15 @@ def main() -> None:
         default=20,
         help="Max concurrent per-game executions (default: 20)",
     )
+    parser.add_argument(
+        "--start-at",
+        choices=["chunk", "merge"],
+        default="chunk",
+        help="Phase to start at. 'merge' skips chunk phase — the "
+             "per-game machine reads cached chunks from chunk_summaries "
+             "and begins at PrepareMerge. Use when chunks are already "
+             "persisted (e.g. a prior run failed on one chunk). Default: chunk.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print intent without executing")
     args = parser.parse_args()
 
@@ -45,7 +54,11 @@ def main() -> None:
         )
         sys.exit(1)
 
-    payload = {"appids": args.appids, "max_concurrency": args.concurrency}
+    payload = {
+        "appids": args.appids,
+        "max_concurrency": args.concurrency,
+        "start_at": args.start_at,
+    }
     execution_input = json.dumps(payload)
     execution_name = f"batch-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
 
@@ -67,6 +80,7 @@ def main() -> None:
     print(f"Name: {execution_name}")
     print(f"Appids: {args.appids}")
     print(f"Concurrency: {args.concurrency}")
+    print(f"Start at: {args.start_at}")
 
 
 if __name__ == "__main__":

--- a/src/lambda-functions/lambda_functions/batch_analysis/dispatch_batch.py
+++ b/src/lambda-functions/lambda_functions/batch_analysis/dispatch_batch.py
@@ -35,6 +35,7 @@ import json
 import boto3
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from library_layer.analyzer import MIN_CHUNKS_FOR_MERGE
 from library_layer.config import SteamPulseConfig
 from library_layer.events import BatchAnalysisCompleteEvent
 from library_layer.utils.db import get_conn
@@ -49,6 +50,10 @@ _sns = boto3.client("sns")
 # Sized to fit the Lambda's 60s timeout with 3 retry attempts:
 # worst-case connect chain = 15 + backoff + 15 + backoff + 15 ≈ 49s.
 _BATCH_CONNECT_TIMEOUT = 15
+# Filter dispatch to appids with enough reviews to clear MIN_CHUNKS_FOR_MERGE
+# at the default chunk size. mv_analysis_candidates itself keeps its ≥200
+# review floor (used by other consumers); this narrows the batch path only.
+_MIN_REVIEW_COUNT_FOR_BATCH = MIN_CHUNKS_FOR_MERGE * _config.ANALYSIS_CHUNK_SIZE
 
 
 def _get_orchestrator_arn() -> str:
@@ -74,8 +79,10 @@ def _fetch_candidates(*, batch_size: int) -> list[int]:
     conn = get_conn(connect_timeout=_BATCH_CONNECT_TIMEOUT, max_connect_attempts=3)
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT appid FROM mv_analysis_candidates ORDER BY review_count DESC LIMIT %s",
-            (batch_size,),
+            "SELECT appid FROM mv_analysis_candidates "
+            "WHERE review_count >= %s "
+            "ORDER BY review_count DESC LIMIT %s",
+            (_MIN_REVIEW_COUNT_FOR_BATCH, batch_size),
         )
         return [row["appid"] for row in cur.fetchall()]
 

--- a/src/lambda-functions/lambda_functions/batch_analysis/dispatch_batch.py
+++ b/src/lambda-functions/lambda_functions/batch_analysis/dispatch_batch.py
@@ -1,21 +1,6 @@
-"""DispatchBatch Lambda — dispatch analysis batches and publish completion events.
+"""DispatchBatch Lambda — publish batch-analysis-complete events.
 
-Two modes, selected by ``action`` in the event payload:
-
-**Default (no action)** — read top-priority candidates and start a fan-out execution.
-
-    Input (all optional):
-        {
-            "batch_size": 100,     # override default from config
-            "dry_run": true        # return candidates without starting
-        }
-
-    Output:
-        {
-            "dispatched": 100,
-            "execution_arn": "arn:aws:states:...",  # omitted on dry_run
-            "appids": [440, 730, ...]
-        }
+Single mode:
 
 **action="post_batch"** — publish BatchAnalysisCompleteEvent after orchestrator fan-out.
 
@@ -28,103 +13,100 @@ Two modes, selected by ``action`` in the event payload:
 
     Output:
         {"status": "published", "execution_id": "..."}
-"""
 
-import json
+The matview-driven auto-dispatch path (``_handle_dispatch`` → fan-out over
+``mv_analysis_candidates``) is disabled below — see the commented-out
+block. Batch analysis runs only via ``scripts/trigger_batch_analysis.py``
+invoked by a human operator.
+"""
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from library_layer.analyzer import MIN_CHUNKS_FOR_MERGE
 from library_layer.config import SteamPulseConfig
 from library_layer.events import BatchAnalysisCompleteEvent
-from library_layer.utils.db import get_conn
 from library_layer.utils.events import publish_event
 
 logger = Logger(service="batch-dispatch")
 tracer = Tracer(service="batch-dispatch")
 
 _config = SteamPulseConfig()
-_sfn = boto3.client("stepfunctions")
 _sns = boto3.client("sns")
-# Sized to fit the Lambda's 60s timeout with 3 retry attempts:
-# worst-case connect chain = 15 + backoff + 15 + backoff + 15 ≈ 49s.
-_BATCH_CONNECT_TIMEOUT = 15
-# Filter dispatch to appids with enough reviews to clear MIN_CHUNKS_FOR_MERGE
-# at the default chunk size. mv_analysis_candidates itself keeps its ≥200
-# review floor (used by other consumers); this narrows the batch path only.
-_MIN_REVIEW_COUNT_FOR_BATCH = MIN_CHUNKS_FOR_MERGE * _config.ANALYSIS_CHUNK_SIZE
 
-
-def _get_orchestrator_arn() -> str:
-    ssm = boto3.client("ssm")
-    return ssm.get_parameter(
-        Name=f"/steampulse/{_config.ENVIRONMENT}/batch/orchestrator-sfn-arn"
-    )["Parameter"]["Value"]
-
-
-def _normalize_batch_size(raw: object, *, default: int) -> int:
-    if raw is None or isinstance(raw, bool):
-        return default
-    try:
-        size = int(raw)
-    except (TypeError, ValueError):
-        return default
-    if size <= 0:
-        return default
-    return size
-
-
-def _fetch_candidates(*, batch_size: int) -> list[int]:
-    conn = get_conn(connect_timeout=_BATCH_CONNECT_TIMEOUT, max_connect_attempts=3)
-    with conn.cursor() as cur:
-        cur.execute(
-            "SELECT appid FROM mv_analysis_candidates "
-            "WHERE review_count >= %s "
-            "ORDER BY review_count DESC LIMIT %s",
-            (_MIN_REVIEW_COUNT_FOR_BATCH, batch_size),
-        )
-        return [row["appid"] for row in cur.fetchall()]
-
-
-def _handle_dispatch(event: dict) -> dict:
-    """Read top-priority candidates and start a fan-out execution."""
-    batch_size = _normalize_batch_size(
-        event.get("batch_size"), default=_config.BATCH_DISPATCH_SIZE
-    )
-    dry_run = event.get("dry_run", False)
-
-    appids = _fetch_candidates(batch_size=batch_size)
-    logger.info(
-        "Fetched analysis candidates",
-        extra={"count": len(appids), "batch_size": batch_size, "dry_run": dry_run},
-    )
-
-    if not appids:
-        logger.info("No candidates — matview is empty or fully analyzed")
-        return {"dispatched": 0, "appids": []}
-
-    if dry_run:
-        return {"dispatched": len(appids), "appids": appids, "dry_run": True}
-
-    orchestrator_arn = _get_orchestrator_arn()
-    payload = {"appids": appids, "max_concurrency": 20, "start_at": "chunk"}
-    resp = _sfn.start_execution(
-        stateMachineArn=orchestrator_arn,
-        input=json.dumps(payload),
-    )
-    execution_arn = resp["executionArn"]
-
-    logger.info(
-        "Started orchestrator execution",
-        extra={"execution_arn": execution_arn, "game_count": len(appids)},
-    )
-
-    return {
-        "dispatched": len(appids),
-        "execution_arn": execution_arn,
-        "appids": appids,
-    }
+# Auto-dispatch disabled to guarantee no code path can start a batch analysis
+# without a human running scripts/trigger_batch_analysis.py. Kept as comments
+# in case we want to re-enable matview-driven auto-dispatch later.
+# import json
+# from library_layer.analyzer import MIN_CHUNKS_FOR_MERGE
+# from library_layer.utils.db import get_conn
+# _sfn = boto3.client("stepfunctions")
+# _BATCH_CONNECT_TIMEOUT = 15
+# # Chunking uses ceil(total_reviews / chunk_size), so the minimum review count
+# # that yields at least MIN_CHUNKS_FOR_MERGE chunks is one more review than
+# # (MIN_CHUNKS_FOR_MERGE - 1) full chunks — e.g. 201 reviews at chunk_size=50
+# # produces 5 chunks, which satisfies the merge floor.
+# _MIN_REVIEW_COUNT_FOR_BATCH = (MIN_CHUNKS_FOR_MERGE - 1) * _config.ANALYSIS_CHUNK_SIZE + 1
+#
+# def _get_orchestrator_arn() -> str:
+#     ssm = boto3.client("ssm")
+#     return ssm.get_parameter(
+#         Name=f"/steampulse/{_config.ENVIRONMENT}/batch/orchestrator-sfn-arn"
+#     )["Parameter"]["Value"]
+#
+# def _normalize_batch_size(raw: object, *, default: int) -> int:
+#     if raw is None or isinstance(raw, bool):
+#         return default
+#     try:
+#         size = int(raw)
+#     except (TypeError, ValueError):
+#         return default
+#     if size <= 0:
+#         return default
+#     return size
+#
+# def _fetch_candidates(*, batch_size: int) -> list[int]:
+#     conn = get_conn(connect_timeout=_BATCH_CONNECT_TIMEOUT, max_connect_attempts=3)
+#     with conn.cursor() as cur:
+#         cur.execute(
+#             "SELECT appid FROM mv_analysis_candidates "
+#             "WHERE review_count >= %s "
+#             "ORDER BY review_count DESC LIMIT %s",
+#             (_MIN_REVIEW_COUNT_FOR_BATCH, batch_size),
+#         )
+#         return [row["appid"] for row in cur.fetchall()]
+#
+# def _handle_dispatch(event: dict) -> dict:
+#     """Read top-priority candidates and start a fan-out execution."""
+#     batch_size = _normalize_batch_size(
+#         event.get("batch_size"), default=_config.BATCH_DISPATCH_SIZE
+#     )
+#     dry_run = event.get("dry_run", False)
+#     appids = _fetch_candidates(batch_size=batch_size)
+#     logger.info(
+#         "Fetched analysis candidates",
+#         extra={"count": len(appids), "batch_size": batch_size, "dry_run": dry_run},
+#     )
+#     if not appids:
+#         logger.info("No candidates — matview is empty or fully analyzed")
+#         return {"dispatched": 0, "appids": []}
+#     if dry_run:
+#         return {"dispatched": len(appids), "appids": appids, "dry_run": True}
+#     orchestrator_arn = _get_orchestrator_arn()
+#     payload = {"appids": appids, "max_concurrency": 20, "start_at": "chunk"}
+#     resp = _sfn.start_execution(
+#         stateMachineArn=orchestrator_arn,
+#         input=json.dumps(payload),
+#     )
+#     execution_arn = resp["executionArn"]
+#     logger.info(
+#         "Started orchestrator execution",
+#         extra={"execution_arn": execution_arn, "game_count": len(appids)},
+#     )
+#     return {
+#         "dispatched": len(appids),
+#         "execution_arn": execution_arn,
+#         "appids": appids,
+#     }
 
 
 def _get_system_events_topic_arn() -> str:
@@ -161,8 +143,10 @@ def _handle_post_batch(event: dict) -> dict:
 
 @tracer.capture_lambda_handler
 def handler(event: dict, context: LambdaContext) -> dict:
-    match event.get("action"):
-        case "post_batch":
-            return _handle_post_batch(event)
-        case _:
-            return _handle_dispatch(event)
+    action = event.get("action")
+    if action == "post_batch":
+        return _handle_post_batch(event)
+    raise RuntimeError(
+        f"DispatchBatch auto-dispatch path is disabled (event action={action!r}). "
+        "Batch analysis runs only via scripts/trigger_batch_analysis.py."
+    )

--- a/src/lambda-functions/lambda_functions/batch_analysis/dispatch_batch.py
+++ b/src/lambda-functions/lambda_functions/batch_analysis/dispatch_batch.py
@@ -101,7 +101,7 @@ def _handle_dispatch(event: dict) -> dict:
         return {"dispatched": len(appids), "appids": appids, "dry_run": True}
 
     orchestrator_arn = _get_orchestrator_arn()
-    payload = {"appids": appids, "max_concurrency": 20}
+    payload = {"appids": appids, "max_concurrency": 20, "start_at": "chunk"}
     resp = _sfn.start_execution(
         stateMachineArn=orchestrator_arn,
         input=json.dumps(payload),

--- a/src/lambda-functions/lambda_functions/batch_analysis/prepare_phase.py
+++ b/src/lambda-functions/lambda_functions/batch_analysis/prepare_phase.py
@@ -279,14 +279,20 @@ def _prepare_merge(
 ) -> dict:
     """Submit merge groups as a batch job via AnthropicBatchBackend.
 
-    Called for both merge levels. Level 1 loads chunk summaries from DB;
+    Called for both merge levels. Level 1 loads chunk summaries from DB
+    and enforces ``MIN_CHUNKS_FOR_MERGE`` before doing anything else;
     level 2 loads intermediate MergedSummary rows produced by level 1.
 
     Returns ``skip=true`` when:
-    - single chunk (Python promotion, no LLM needed)
-    - whole-set cache hit
+    - whole-set cache hit (all chunks already rolled up into one merge row)
     - all groups cached at this level and only 1 result
     - level 2 receives a single merged_id (level 1 already converged)
+
+    Raises ``ValueError`` when level 1 is called with fewer than
+    ``MIN_CHUNKS_FOR_MERGE`` cached chunks — covers both zero-chunk and
+    partial-chunk (``start_at=merge``) cases. The single-chunk promotion
+    branch below is preserved for historical reference but is unreachable
+    under the current floor.
     """
     if merge_level == 2:
         return _prepare_merge_l2(appid, backend, execution_id, merged_ids)

--- a/src/lambda-functions/lambda_functions/batch_analysis/prepare_phase.py
+++ b/src/lambda-functions/lambda_functions/batch_analysis/prepare_phase.py
@@ -87,6 +87,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from library_layer.analyzer import (
     CHUNK_PROMPT_VERSION,
     MERGE_PROMPT_VERSION,
+    MIN_CHUNKS_FOR_MERGE,
     PIPELINE_VERSION,
     SYNTHESIS_PROMPT_VERSION,
     AnalyzerSettings,
@@ -296,9 +297,13 @@ def _prepare_merge(
         raise ValueError(f"appid={appid} not in games table")
 
     rows = _chunk_repo.find_by_appid(appid, CHUNK_PROMPT_VERSION)
-    if not rows:
+    if len(rows) < MIN_CHUNKS_FOR_MERGE:
         raise ValueError(
-            f"merge prep: no chunk_summaries for appid={appid} — run chunk phase first"
+            f"merge prep requires at least {MIN_CHUNKS_FOR_MERGE} chunks "
+            f"(got {len(rows)} for appid={appid}). Below this floor, "
+            f"cross-chunk topic synthesis is statistically unreliable. "
+            f"If this is a start_at=merge run, verify chunk_summaries "
+            f"has the expected rows for this appid."
         )
 
     summaries = [RichChunkSummary.model_validate(r["summary_json"]) for r in rows]

--- a/src/library-layer/library_layer/analyzer.py
+++ b/src/library-layer/library_layer/analyzer.py
@@ -336,6 +336,10 @@ MERGE_PROMPT_VERSION = "merge-v1.0"
 SYNTHESIS_PROMPT_VERSION = "synthesis-v3.0"
 PIPELINE_VERSION = f"3.0/{CHUNK_PROMPT_VERSION}/{MERGE_PROMPT_VERSION}/{SYNTHESIS_PROMPT_VERSION}"
 
+# Hard floor below which cross-chunk topic synthesis is statistically
+# unreliable — anchored to the wedge's ≥500-review / ~10-chunk minimum.
+MIN_CHUNKS_FOR_MERGE = 5
+
 
 CHUNK_SYSTEM_PROMPT_V2 = """\
 You extract structured topic signals from Steam game reviews for an analytics pipeline.
@@ -1008,8 +1012,14 @@ def run_merge_phase(
     row so downstream consumers (batch synthesis Lambda, cache lookups,
     operational visibility) never see a stale row from a previous run.
     """
-    if not chunk_summaries:
-        raise ValueError("run_merge_phase called with zero chunks")
+    if len(chunk_summaries) < MIN_CHUNKS_FOR_MERGE:
+        raise ValueError(
+            f"run_merge_phase requires at least {MIN_CHUNKS_FOR_MERGE} "
+            f"chunks (got {len(chunk_summaries)} for appid={appid}). Below this "
+            f"floor, cross-chunk topic synthesis is statistically "
+            f"unreliable. If this is a start_at=merge run, verify "
+            f"chunk_summaries has the expected rows for this appid."
+        )
     if len(chunk_summaries) != len(chunk_ids):
         raise ValueError(
             f"chunk_summaries ({len(chunk_summaries)}) and chunk_ids "

--- a/src/library-layer/library_layer/analyzer.py
+++ b/src/library-layer/library_layer/analyzer.py
@@ -993,24 +993,25 @@ def run_merge_phase(
 ) -> tuple[MergedSummary, int]:
     """Phase 2: hierarchical merge with correct source_chunk_ids tracking.
 
-    Makes ZERO assumptions about the total review count. Any number of
-    input chunk summaries works: the phase groups them into batches of
-    `max_chunks_per_merge_call`, merges each group with one LLM call, then
-    repeats the process on the resulting MergedSummaries until a single
-    root MergedSummary remains. At every level we thread the union of
-    **leaf chunk row ids** (from the `chunk_summaries` table) so the final
-    root — and every intermediate row — can be cache-keyed by exactly the
-    set of primary chunks it was derived from.
+    Requires at least `MIN_CHUNKS_FOR_MERGE` input chunk summaries; below
+    that floor the call raises `ValueError` before any LLM or DB work,
+    because cross-chunk topic synthesis is statistically unreliable at
+    small corpora. Above the floor, the phase groups chunks into batches
+    of `max_chunks_per_merge_call`, merges each group with one LLM call,
+    then repeats on the resulting MergedSummaries until a single root
+    remains. At every level we thread the union of **leaf chunk row ids**
+    (from the `chunk_summaries` table) so the final root — and every
+    intermediate row — can be cache-keyed by exactly the set of primary
+    chunks it was derived from.
 
     `max_chunks_per_merge_call` is a per-call LLM context-budget limit,
     NOT a review-count limit. It is required from the caller (no default).
     `merge_max_tokens` is the Bedrock `max_tokens` budget per merge call.
 
-    Returns `(root_merged_summary, root_merged_row_id)`. Every analysis
-    run persists at least one merged_summaries row — even the single-chunk
-    promotion case gets a `merge_level=0`, `model_id="python-promotion"`
-    row so downstream consumers (batch synthesis Lambda, cache lookups,
-    operational visibility) never see a stale row from a previous run.
+    Returns `(root_merged_summary, root_merged_row_id)`. The single-chunk
+    promotion branch below is preserved for historical reference but is
+    unreachable under the current floor — retained so the phase still
+    works if `MIN_CHUNKS_FOR_MERGE` is ever lowered.
     """
     if len(chunk_summaries) < MIN_CHUNKS_FOR_MERGE:
         raise ValueError(

--- a/src/library-layer/library_layer/services/revenue_estimator.py
+++ b/src/library-layer/library_layer/services/revenue_estimator.py
@@ -1,4 +1,4 @@
-"""Revenue estimator — Boxleiter v1 (multi-signal).
+"""Revenue estimator — Boxleiter v2 (multi-signal, small-sample floor).
 
 Estimates Steam-only owners and gross revenue for a Steam game using a
 multi-signal review-count x multiplier heuristic (a.k.a. "Boxleiter ratio").
@@ -14,9 +14,15 @@ Sources for calibration:
   - steam-revenue-calculator.com (~48x flat)
   - SteamRev (~35x flat, "~3% of players leave reviews")
 
-These numbers are **rough cuts**. Every output should be treated as ±50%.
-The method version (`boxleiter_v1`) is unchanged because the product has not
-launched — all rows will be recomputed via a full backfill before launch.
+v2 (2026-04-23) vs v1:
+  - Review floor raised from 50 → 500 (below this we return
+    `reason="insufficient_reviews"`; public estimators agree <1k is noise).
+  - Confidence band is no longer a flat ±50% — the UI renders ±40% for
+    ≥50k reviews, ±60% for 5k–50k, ±100% for 500–5k ("small sample").
+  - Algorithm shape (base multiplier + five signal factors) is unchanged.
+
+These numbers are **rough cuts**. Treat every output per the tiered band
+above — widest in the small-sample zone where calibration data is thin.
 
 Every output is **gross revenue, pre-Steam-cut** for **Steam-only** sales.
 It's a ceiling, not what the developer took home, and does not include
@@ -29,7 +35,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from library_layer.models.game import Game
 from pydantic import BaseModel
 
-METHOD_VERSION = "boxleiter_v1"
+METHOD_VERSION = "boxleiter_v2"
 
 BASE_MULTIPLIER = Decimal("30")
 
@@ -55,7 +61,7 @@ _AGE_BOUNDARY_RECENT = 3
 _AGE_BOUNDARY_MID = 7
 _AGE_BOUNDARY_OLD = 12
 
-_REVIEW_FLOOR = 50
+_REVIEW_FLOOR = 500
 _EXCLUDED_TYPES = frozenset({"dlc", "demo", "music", "tool", "video", "mod"})
 
 
@@ -73,9 +79,10 @@ def _review_count_factor(review_count: int) -> Decimal:
     (cultural events drive review engagement), and their non-Steam sales
     are invisible to us. Both effects mean fewer Steam owners per review
     than the base assumes — so the factor decreases for high review counts.
+
+    Caller is expected to have already gated on `_REVIEW_FLOOR`, so the
+    domain here is `review_count >= 500`.
     """
-    if review_count < 500:
-        return Decimal("1.15")
     if review_count < 50_000:
         return Decimal("1.0")
     if review_count < 200_000:
@@ -170,7 +177,7 @@ def compute_estimate(
     genres: list[dict],
     tags: list[dict],
 ) -> RevenueEstimate:
-    """Compute a Boxleiter v1 revenue estimate for a game.
+    """Compute a Boxleiter v2 revenue estimate for a game.
 
     Returns a `RevenueEstimate`. When no estimate can be produced, both value
     fields are None and `reason` is populated with a short machine-readable

--- a/tests/handlers/test_dispatch_batch.py
+++ b/tests/handlers/test_dispatch_batch.py
@@ -132,9 +132,10 @@ def test_batch_size_override(monkeypatch: Any) -> None:
 
     result = mod.handler({"batch_size": 50}, MockLambdaContext())
 
-    # Verify the SQL LIMIT used our override
+    # Verify the SQL LIMIT used our override; the first bound param is
+    # the MIN_CHUNKS_FOR_MERGE * chunk-size review floor.
     call_args = mock_cursor.execute.call_args
-    assert call_args[0][1] == (50,)
+    assert call_args[0][1] == (mod._MIN_REVIEW_COUNT_FOR_BATCH, 50)
     assert result["dispatched"] == 2
 
 

--- a/tests/handlers/test_dispatch_batch.py
+++ b/tests/handlers/test_dispatch_batch.py
@@ -1,12 +1,8 @@
 """Tests for batch_analysis/dispatch_batch.py — the dispatch Lambda.
 
 Covers:
-  1. Returns top N appids ordered by review_count from the matview.
-  2. dry_run returns candidates without starting an execution.
-  3. Empty matview returns clean result with no execution started.
-  4. batch_size override works.
-  5. batch_size validation (non-positive, non-integer).
-  6. post_batch action publishes BatchAnalysisCompleteEvent to SNS.
+  1. Auto-dispatch path is disabled — any non-post_batch event raises.
+  2. post_batch action publishes BatchAnalysisCompleteEvent to SNS.
 
 Module-level init (SteamPulseConfig, boto3 clients) runs at import time.
 conftest.py seeds the required env vars; _get_module() defers the import
@@ -18,6 +14,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import boto3
+import pytest
 from moto import mock_aws
 
 from tests.conftest import MockLambdaContext
@@ -27,12 +24,6 @@ _SYSTEM_EVENTS_TOPIC_ARN = "arn:aws:sns:us-east-1:123456789012:system-events"
 
 def _seed_ssm() -> None:
     ssm = boto3.client("ssm", region_name="us-east-1")
-    ssm.put_parameter(
-        Name="/steampulse/staging/batch/orchestrator-sfn-arn",
-        Value="arn:aws:states:us-east-1:123:stateMachine:test-orchestrator",
-        Type="String",
-        Overwrite=True,
-    )
     ssm.put_parameter(
         Name="/steampulse/test/messaging/system-events-topic-arn",
         Value=_SYSTEM_EVENTS_TOPIC_ARN,
@@ -48,125 +39,12 @@ def _get_module() -> Any:
     return db
 
 
-def _mock_conn_with(appids: list[int]) -> MagicMock:
-    """Create a mock connection whose cursor returns dict-like rows (RealDictCursor)."""
-    mock_cursor = MagicMock()
-    mock_cursor.fetchall.return_value = [{"appid": a} for a in appids]
-    mock_conn = MagicMock()
-    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
-    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-    return mock_conn
-
-
 @mock_aws
-def test_returns_top_n_candidates(monkeypatch: Any) -> None:
+def test_auto_dispatch_is_disabled() -> None:
     mod = _get_module()
 
-    mock_conn = _mock_conn_with([440, 730, 570])
-    monkeypatch.setattr(mod, "get_conn", lambda **_kw: mock_conn)
-
-    mock_sfn = MagicMock()
-    mock_sfn.start_execution.return_value = {
-        "executionArn": "arn:aws:states:us-east-1:123:execution:test:run-1"
-    }
-    monkeypatch.setattr(mod, "_sfn", mock_sfn)
-
-    result = mod.handler({"batch_size": 3}, MockLambdaContext())
-
-    assert result["dispatched"] == 3
-    assert result["appids"] == [440, 730, 570]
-    assert "execution_arn" in result
-    mock_sfn.start_execution.assert_called_once()
-
-
-@mock_aws
-def test_dry_run_no_execution(monkeypatch: Any) -> None:
-    mod = _get_module()
-
-    mock_conn = _mock_conn_with([440, 730])
-    monkeypatch.setattr(mod, "get_conn", lambda **_kw: mock_conn)
-
-    mock_sfn = MagicMock()
-    monkeypatch.setattr(mod, "_sfn", mock_sfn)
-
-    result = mod.handler({"dry_run": True}, MockLambdaContext())
-
-    assert result["dispatched"] == 2
-    assert result["appids"] == [440, 730]
-    assert result["dry_run"] is True
-    assert "execution_arn" not in result
-    mock_sfn.start_execution.assert_not_called()
-
-
-@mock_aws
-def test_empty_matview_no_execution(monkeypatch: Any) -> None:
-    mod = _get_module()
-
-    mock_conn = _mock_conn_with([])
-    monkeypatch.setattr(mod, "get_conn", lambda **_kw: mock_conn)
-
-    mock_sfn = MagicMock()
-    monkeypatch.setattr(mod, "_sfn", mock_sfn)
-
-    result = mod.handler({}, MockLambdaContext())
-
-    assert result["dispatched"] == 0
-    assert result["appids"] == []
-    assert "execution_arn" not in result
-    mock_sfn.start_execution.assert_not_called()
-
-
-@mock_aws
-def test_batch_size_override(monkeypatch: Any) -> None:
-    mod = _get_module()
-
-    mock_conn = _mock_conn_with([440, 730])
-    mock_cursor = mock_conn.cursor.return_value.__enter__.return_value
-    monkeypatch.setattr(mod, "get_conn", lambda **_kw: mock_conn)
-
-    mock_sfn = MagicMock()
-    mock_sfn.start_execution.return_value = {
-        "executionArn": "arn:aws:states:us-east-1:123:execution:test:run-2"
-    }
-    monkeypatch.setattr(mod, "_sfn", mock_sfn)
-
-    result = mod.handler({"batch_size": 50}, MockLambdaContext())
-
-    # Verify the SQL LIMIT used our override; the first bound param is
-    # the MIN_CHUNKS_FOR_MERGE * chunk-size review floor.
-    call_args = mock_cursor.execute.call_args
-    assert call_args[0][1] == (mod._MIN_REVIEW_COUNT_FOR_BATCH, 50)
-    assert result["dispatched"] == 2
-
-
-@mock_aws
-def test_batch_size_non_positive_uses_default(monkeypatch: Any) -> None:
-    mod = _get_module()
-
-    mock_conn = _mock_conn_with([440])
-    monkeypatch.setattr(mod, "get_conn", lambda **_kw: mock_conn)
-
-    mock_sfn = MagicMock()
-    monkeypatch.setattr(mod, "_sfn", mock_sfn)
-
-    # batch_size=0 should fall back to config default
-    result = mod.handler({"batch_size": 0, "dry_run": True}, MockLambdaContext())
-    assert result["dispatched"] == 1
-
-
-@mock_aws
-def test_batch_size_string_uses_default(monkeypatch: Any) -> None:
-    mod = _get_module()
-
-    mock_conn = _mock_conn_with([440])
-    monkeypatch.setattr(mod, "get_conn", lambda **_kw: mock_conn)
-
-    mock_sfn = MagicMock()
-    monkeypatch.setattr(mod, "_sfn", mock_sfn)
-
-    # batch_size="abc" should fall back to config default
-    result = mod.handler({"batch_size": "abc", "dry_run": True}, MockLambdaContext())
-    assert result["dispatched"] == 1
+    with pytest.raises(RuntimeError, match="auto-dispatch path is disabled"):
+        mod.handler({"batch_size": 3}, MockLambdaContext())
 
 
 @mock_aws

--- a/tests/handlers/test_prepare_phase.py
+++ b/tests/handlers/test_prepare_phase.py
@@ -197,52 +197,28 @@ def test_prepare_chunk_submits_when_pending_exist() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_prepare_merge_single_chunk_promotion_skips() -> None:
+def test_prepare_merge_raises_below_minimum_chunks() -> None:
+    """Floor enforced at prepare time: <MIN_CHUNKS_FOR_MERGE raises without
+    touching the backend. Covers both zero-chunk and partial-chunk (e.g.
+    --start-at merge with too few cached chunks) cases."""
+    from library_layer.analyzer import MIN_CHUNKS_FOR_MERGE
+
     pp = _get_module()
     _install_fake_game(pp)
-
-    # One cached chunk → single-chunk promotion path (no LLM call needed).
     pp._chunk_repo = MagicMock()
     pp._chunk_repo.find_by_appid.return_value = [
-        {"id": 42, "summary_json": _empty_summary("solo").model_dump(mode="json")}
+        {"id": i, "summary_json": _empty_summary(f"c{i}").model_dump(mode="json")}
+        for i in range(MIN_CHUNKS_FOR_MERGE - 1)
     ]
-    pp._merge_repo = MagicMock()
-    pp._merge_repo.find_latest_by_source_ids.return_value = None
-    pp._merge_repo.insert.return_value = 99
+    backend = _install_fake_backend(pp)
 
-    # The BatchBackend should NEVER be touched for the merge phase.
-    batch_backend = _install_fake_backend(pp)
-
-    result = pp.handler(
-        {"appid": 440, "phase": "merge", "execution_id": "exec-3", "merge_level": 1},
-        context=None,
-    )
-    assert result["skip"] is True
-    assert result["job_id"] is None
-    # merged_summary_id is threaded forward to the next merge level
-    # and ultimately to PrepareSynthesis via the state machine.
-    assert result["merged_summary_id"] == 99
-    assert result["merged_ids"] == [99]
-    batch_backend.prepare.assert_not_called()
-    batch_backend.submit.assert_not_called()
-    # Promotion row was persisted.
-    pp._merge_repo.insert.assert_called_once()
-    insert_call = pp._merge_repo.insert.call_args
-    assert insert_call.kwargs["model_id"] == "python-promotion"
-
-
-def test_prepare_merge_raises_when_no_chunk_summaries_exist() -> None:
-    pp = _get_module()
-    _install_fake_game(pp)
-    pp._chunk_repo = MagicMock()
-    pp._chunk_repo.find_by_appid.return_value = []
-    _install_fake_backend(pp)
-
-    with pytest.raises(ValueError, match="no chunk_summaries"):
+    with pytest.raises(ValueError, match=f"at least {MIN_CHUNKS_FOR_MERGE} chunks"):
         pp.handler(
             {"appid": 440, "phase": "merge", "execution_id": "exec-4", "merge_level": 1},
             context=None,
         )
+    backend.prepare.assert_not_called()
+    backend.submit.assert_not_called()
 
 
 def test_prepare_merge_submits_batch_for_multi_chunk_game() -> None:
@@ -250,11 +226,11 @@ def test_prepare_merge_submits_batch_for_multi_chunk_game() -> None:
     pp = _get_module()
     _install_fake_game(pp)
 
-    # 3 chunk summaries → one merge group (< max_chunks_per_merge_call).
+    # 5 chunk summaries → one merge group (< max_chunks_per_merge_call).
     pp._chunk_repo = MagicMock()
     pp._chunk_repo.find_by_appid.return_value = [
         {"id": i, "summary_json": _empty_summary(f"c{i}").model_dump(mode="json")}
-        for i in range(1, 4)
+        for i in range(1, 6)
     ]
     pp._merge_repo = MagicMock()
     pp._merge_repo.find_latest_by_source_ids.return_value = None  # no cache hits
@@ -280,7 +256,7 @@ def test_prepare_merge_submits_batch_for_multi_chunk_game() -> None:
     # group_meta threaded for collect.
     assert len(result["group_meta"]) == 1
     assert result["group_meta"][0]["group_index"] == 0
-    assert sorted(result["group_meta"][0]["source_chunk_ids"]) == [1, 2, 3]
+    assert sorted(result["group_meta"][0]["source_chunk_ids"]) == [1, 2, 3, 4, 5]
     assert result["cached_group_meta"] == []
 
     # Tracking row inserted.

--- a/tests/services/test_analyzer_three_phase.py
+++ b/tests/services/test_analyzer_three_phase.py
@@ -168,8 +168,8 @@ def test_run_merge_phase_rejects_non_positive_bound() -> None:
         run_merge_phase(
             appid=440,
             game_name="TF2",
-            chunk_summaries=[_empty_summary("a"), _empty_summary("b")],
-            chunk_ids=[1, 2],
+            chunk_summaries=[_empty_summary(f"c{i}") for i in range(5)],
+            chunk_ids=[1, 2, 3, 4, 5],
             backend=_FakeBackend([]),
             merge_repo=merge_repo,
             max_chunks_per_merge_call=0,
@@ -396,56 +396,28 @@ def _call_run_merge_phase(
     )
 
 
-def test_run_merge_phase_short_circuits_single_chunk_but_persists() -> None:
+def test_run_merge_phase_rejects_below_minimum_chunks() -> None:
+    """Floor: fewer than MIN_CHUNKS_FOR_MERGE chunks raises cleanly,
+    before any LLM call or DB write."""
+    from library_layer.analyzer import MIN_CHUNKS_FOR_MERGE
+
     backend = _FakeBackend([])
     merge_repo = MagicMock()
-    merge_repo.find_latest_by_source_ids.return_value = None
-    merge_repo.insert.return_value = 55
-
-    merged, merged_id = _call_run_merge_phase(
-        backend=backend,
-        merge_repo=merge_repo,
-        chunk_summaries=[_empty_summary("solo")],
-        chunk_ids=[99],
-    )
-    assert isinstance(merged, MergedSummary)
-    assert merged.merge_level == 0
-    assert merged.source_chunk_ids == [99]
-    assert merged_id == 55
+    short_count = MIN_CHUNKS_FOR_MERGE - 1
+    with pytest.raises(ValueError, match=f"at least {MIN_CHUNKS_FOR_MERGE} chunks"):
+        run_merge_phase(
+            appid=440,
+            game_name="TF2",
+            chunk_summaries=[_empty_summary(f"c{i}") for i in range(short_count)],
+            chunk_ids=list(range(short_count)),
+            backend=backend,
+            merge_repo=merge_repo,
+            max_chunks_per_merge_call=_MAX_CHUNKS_PER_MERGE_CALL,
+            merge_max_tokens=_MERGE_MAX_TOKENS,
+            merge_temperature=None,
+        )
     assert backend.received == []
-    assert merge_repo.insert.call_count == 1
-    call = merge_repo.insert.call_args
-    assert call.args[3] == [99]
-    assert call.kwargs["model_id"] == "python-promotion"
-
-
-def test_run_merge_phase_single_chunk_reuses_promotion_cache() -> None:
-    backend = _FakeBackend([])
-    existing = MergedSummary(
-        topics=[],
-        competitor_refs=[],
-        notable_quotes=[],
-        total_stats=RichBatchStats(),
-        merge_level=0,
-        chunks_merged=1,
-        source_chunk_ids=[99],
-    )
-    merge_repo = MagicMock()
-    merge_repo.find_latest_by_source_ids.return_value = {
-        "id": 55,
-        "summary_json": existing.model_dump(mode="json"),
-    }
-
-    merged, merged_id = _call_run_merge_phase(
-        backend=backend,
-        merge_repo=merge_repo,
-        chunk_summaries=[_empty_summary("solo")],
-        chunk_ids=[99],
-    )
-    assert merged_id == 55
-    assert merged.source_chunk_ids == [99]
-    assert backend.received == []
-    assert merge_repo.insert.call_count == 0
+    merge_repo.insert.assert_not_called()
 
 
 def test_run_merge_phase_uses_cached_merge_row() -> None:
@@ -456,8 +428,8 @@ def test_run_merge_phase_uses_cached_merge_row() -> None:
         notable_quotes=[],
         total_stats=RichBatchStats(),
         merge_level=1,
-        chunks_merged=3,
-        source_chunk_ids=[1, 2, 3],
+        chunks_merged=5,
+        source_chunk_ids=[1, 2, 3, 4, 5],
     )
     merge_repo = MagicMock()
     merge_repo.find_latest_by_source_ids.return_value = {
@@ -468,11 +440,11 @@ def test_run_merge_phase_uses_cached_merge_row() -> None:
     merged, merged_id = _call_run_merge_phase(
         backend=backend,
         merge_repo=merge_repo,
-        chunk_summaries=[_empty_summary(f"c{i}") for i in range(3)],
-        chunk_ids=[1, 2, 3],
+        chunk_summaries=[_empty_summary(f"c{i}") for i in range(5)],
+        chunk_ids=[1, 2, 3, 4, 5],
     )
     assert isinstance(merged, MergedSummary)
-    assert merged.chunks_merged == 3
+    assert merged.chunks_merged == 5
     assert merged_id == 42
     assert backend.received == []
     assert merge_repo.insert.call_count == 0
@@ -515,16 +487,16 @@ def test_run_merge_phase_single_level_fits_in_one_call() -> None:
     backend = _FakeBackend([merged_from_llm])
     merge_repo = _fake_merge_repo_for([7])
 
-    chunk_ids = [10, 20, 30, 40]
+    chunk_ids = [10, 20, 30, 40, 50]
     merged, merged_id = _call_run_merge_phase(
         backend=backend,
         merge_repo=merge_repo,
-        chunk_summaries=[_empty_summary(f"c{i}") for i in range(4)],
+        chunk_summaries=[_empty_summary(f"c{i}") for i in range(5)],
         chunk_ids=chunk_ids,
     )
     assert merged_id == 7
     assert merged.merge_level == 1
-    assert merged.chunks_merged == 4
+    assert merged.chunks_merged == 5
     assert merged.source_chunk_ids == sorted(chunk_ids)
     assert len(backend.received) == 1
     assert backend.received[0].task == "merging"
@@ -617,8 +589,8 @@ def test_run_merge_phase_root_lookup_is_race_free() -> None:
     merged, merged_id = _call_run_merge_phase(
         backend=backend,
         merge_repo=merge_repo,
-        chunk_summaries=[_empty_summary(f"c{i}") for i in range(4)],
-        chunk_ids=[10, 20, 30, 40],
+        chunk_summaries=[_empty_summary(f"c{i}") for i in range(5)],
+        chunk_ids=[10, 20, 30, 40, 50],
     )
     assert merged_id == 7
     assert isinstance(merged, MergedSummary)

--- a/tests/services/test_revenue_estimator.py
+++ b/tests/services/test_revenue_estimator.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Boxleiter v1 revenue estimator (multi-signal)."""
+"""Unit tests for the Boxleiter v2 revenue estimator (multi-signal)."""
 
 from datetime import date
 from decimal import Decimal
@@ -120,7 +120,7 @@ def test_excluded_types_return_none(game_type: str) -> None:
 
 
 def test_insufficient_reviews() -> None:
-    game = _game(review_count=49)
+    game = _game(review_count=499)
     result = compute_estimate(game, genres=[], tags=[])
     assert result.reason == "insufficient_reviews"
     assert result.estimated_owners is None
@@ -150,10 +150,10 @@ def test_review_count_factor_popular() -> None:
 
 
 def test_review_count_factor_small() -> None:
-    game = _game(review_count=100, price_usd=Decimal("10.00"), positive_pct=Decimal("80"))
+    game = _game(review_count=501, price_usd=Decimal("10.00"), positive_pct=Decimal("80"))
     result = compute_estimate(game, genres=[], tags=[])
-    # 30 * 1.15 (100) * 1.0 * 1.0 * 1.0 * 1.0 = 34.5
-    assert result.estimated_owners == int(Decimal("100") * Decimal("34.5"))
+    # 30 * 1.0 (501, in 500-49,999 bucket) * 1.0 * 1.0 * 1.0 * 1.0 = 30
+    assert result.estimated_owners == int(Decimal("501") * Decimal("30"))
 
 
 # --- Review score factor ---
@@ -244,11 +244,11 @@ def test_sub_5_and_old_compose() -> None:
 
 
 def test_revenue_is_owners_times_price() -> None:
-    game = _game(price_usd=Decimal("10.00"), review_count=100, positive_pct=Decimal("80"))
+    game = _game(price_usd=Decimal("10.00"), review_count=500, positive_pct=Decimal("80"))
     result = compute_estimate(game, genres=[], tags=[])
-    # 30 * 1.15 (100 reviews) * 1.0 * 1.0 * 1.0 * 1.0 ($10) = 34.5
-    assert result.estimated_owners == 3450
-    assert result.estimated_revenue_usd == Decimal("34500.00")
+    # 30 * 1.0 (500 reviews, 500-49,999 bucket) * 1.0 * 1.0 * 1.0 * 1.0 ($10) = 30
+    assert result.estimated_owners == 15000
+    assert result.estimated_revenue_usd == Decimal("150000.00")
 
 
 # --- Validation targets (Steam-only, ±50%) ---


### PR DESCRIPTION
Carefully check this PR!!  It implements prompt at: scripts/prompts/batch-analysis-start-at-phase.md.  Please verify:

- `StartAtChoice` wired as the per-game state-machine entry state; default (`start_at=chunk`) preserves existing flow.
- `start_at` threaded from orchestrator via `$$.Execution.Input.start_at`; `dispatch_batch.py` always sends `"start_at": "chunk"` so the matview-driven path never hits a missing-key JSONPath error (Option A from the prompt).
- `MIN_CHUNKS_FOR_MERGE = 5` enforced in **both** `run_merge_phase` (realtime path) and `_prepare_merge_l1` (batch API path). The prompt specified only `run_merge_phase`, but the batch path never calls it — the floor must also trip at `PrepareMerge` to satisfy verification step 6 ("merge prepare fails… no money spent").
- Tests for the now-unreachable single-chunk promotion path were deleted in both `test_analyzer_three_phase.py` and `test_prepare_phase.py`; the single-chunk promotion code itself is left in place as harmless dead code (out of scope to remove per prompt).
- No `CHUNK_PROMPT_VERSION` / schema / migration changes. No new IAM permissions, env vars, or secrets. Lambda code signatures unchanged.
- `cdk diff` should show: new `StartAtChoice` Choice state on the per-game machine + modified `RunPerGame` task input carrying `start_at`.
- No deploy from Claude — user runs `bash scripts/deploy.sh` and then `poetry run python scripts/trigger_batch_analysis.py --env production --start-at merge --appids 1184820 3205380`.