### PR TITLE
feature/search-autocomplete-ux-and-perf: fix spinner gap, cache repeats

### DIFF
--- a/frontend/components/layout/SearchAutocomplete.tsx
+++ b/frontend/components/layout/SearchAutocomplete.tsx
@@ -98,9 +98,6 @@ export function SearchAutocomplete({
       return;
     }
 
-    // Abort any in-flight request even on cache hits — its late .then() would otherwise overwrite fresh state.
-    if (abortRef.current) abortRef.current.abort();
-
     const cached = cacheRef.current.get(normalized);
     if (cached) {
       setSuggestions(cached);
@@ -110,17 +107,17 @@ export function SearchAutocomplete({
       return;
     }
 
-    abortRef.current = new AbortController();
-    const signal = abortRef.current.signal;
+    const controller = new AbortController();
+    abortRef.current = controller;
 
     setLoading(true);
 
     getGames(
       { q: normalized, limit: 6, sort: "review_count", fields: "compact" },
-      signal,
+      controller.signal,
     )
       .then((res) => {
-        if (signal.aborted) return;
+        if (controller.signal.aborted) return;
         cacheRef.current.set(normalized, res.games);
         if (cacheRef.current.size > 20) {
           const oldest = cacheRef.current.keys().next().value;
@@ -132,9 +129,11 @@ export function SearchAutocomplete({
         setActiveIndex(-1);
       })
       .catch(() => {
-        if (signal.aborted) return;
+        if (controller.signal.aborted) return;
         setLoading(false);
       });
+
+    return () => controller.abort();
   }, [debouncedQuery]);
 
   // Close on route change

--- a/frontend/components/layout/SearchAutocomplete.tsx
+++ b/frontend/components/layout/SearchAutocomplete.tsx
@@ -130,7 +130,10 @@ export function SearchAutocomplete({
       })
       .catch(() => {
         if (controller.signal.aborted) return;
+        setSuggestions([]);
+        setOpen(false);
         setLoading(false);
+        setActiveIndex(-1);
       });
 
     return () => controller.abort();

--- a/frontend/components/layout/SearchAutocomplete.tsx
+++ b/frontend/components/layout/SearchAutocomplete.tsx
@@ -90,15 +90,18 @@ export function SearchAutocomplete({
 
   // Prior list stays visible behind the spinner so the dropdown never flashes empty during refetch.
   useEffect(() => {
-    if (debouncedQuery.length < 2) {
+    const normalized = debouncedQuery.toLowerCase().trim();
+    if (normalized.length < 2) {
       setSuggestions([]);
       setOpen(false);
       setLoading(false);
       return;
     }
 
-    const key = debouncedQuery.toLowerCase().trim();
-    const cached = cacheRef.current.get(key);
+    // Abort any in-flight request even on cache hits — its late .then() would otherwise overwrite fresh state.
+    if (abortRef.current) abortRef.current.abort();
+
+    const cached = cacheRef.current.get(normalized);
     if (cached) {
       setSuggestions(cached);
       setOpen(cached.length > 0);
@@ -107,19 +110,18 @@ export function SearchAutocomplete({
       return;
     }
 
-    if (abortRef.current) abortRef.current.abort();
     abortRef.current = new AbortController();
     const signal = abortRef.current.signal;
 
     setLoading(true);
 
     getGames(
-      { q: debouncedQuery, limit: 6, sort: "review_count", fields: "compact" },
+      { q: normalized, limit: 6, sort: "review_count", fields: "compact" },
       signal,
     )
       .then((res) => {
         if (signal.aborted) return;
-        cacheRef.current.set(key, res.games);
+        cacheRef.current.set(normalized, res.games);
         if (cacheRef.current.size > 20) {
           const oldest = cacheRef.current.keys().next().value;
           if (oldest !== undefined) cacheRef.current.delete(oldest);

--- a/frontend/components/layout/SearchAutocomplete.tsx
+++ b/frontend/components/layout/SearchAutocomplete.tsx
@@ -84,10 +84,11 @@ export function SearchAutocomplete({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const cacheRef = useRef<Map<string, Game[]>>(new Map());
 
   const debouncedQuery = useDebounce(value, 300);
 
-  // Fetch suggestions
+  // Prior list stays visible behind the spinner so the dropdown never flashes empty during refetch.
   useEffect(() => {
     if (debouncedQuery.length < 2) {
       setSuggestions([]);
@@ -96,22 +97,33 @@ export function SearchAutocomplete({
       return;
     }
 
+    const key = debouncedQuery.toLowerCase().trim();
+    const cached = cacheRef.current.get(key);
+    if (cached) {
+      setSuggestions(cached);
+      setOpen(cached.length > 0);
+      setLoading(false);
+      setActiveIndex(-1);
+      return;
+    }
+
     if (abortRef.current) abortRef.current.abort();
     abortRef.current = new AbortController();
     const signal = abortRef.current.signal;
 
     setLoading(true);
-    const timeout = setTimeout(() => {
-      if (!signal.aborted) {
-        setSuggestions([]);
-        setLoading(false);
-      }
-    }, 3000);
 
-    getGames({ q: debouncedQuery, limit: 6, sort: "review_count" })
+    getGames(
+      { q: debouncedQuery, limit: 6, sort: "review_count", fields: "compact" },
+      signal,
+    )
       .then((res) => {
         if (signal.aborted) return;
-        clearTimeout(timeout);
+        cacheRef.current.set(key, res.games);
+        if (cacheRef.current.size > 20) {
+          const oldest = cacheRef.current.keys().next().value;
+          if (oldest !== undefined) cacheRef.current.delete(oldest);
+        }
         setSuggestions(res.games);
         setOpen(res.games.length > 0);
         setLoading(false);
@@ -119,12 +131,8 @@ export function SearchAutocomplete({
       })
       .catch(() => {
         if (signal.aborted) return;
-        clearTimeout(timeout);
-        setSuggestions([]);
         setLoading(false);
       });
-
-    return () => clearTimeout(timeout);
   }, [debouncedQuery]);
 
   // Close on route change

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -125,6 +125,7 @@ export async function getGames(
   sort?: string;
   limit?: number;
   offset?: number;
+  fields?: "compact";
 },
   signal?: AbortSignal,
 ): Promise<GamesResponse> {
@@ -144,11 +145,9 @@ export async function getGames(
   if (params?.sort) qs.set("sort", params.sort);
   if (params?.limit) qs.set("limit", String(params.limit));
   if (params?.offset) qs.set("offset", String(params.offset));
+  if (params?.fields) qs.set("fields", params.fields);
   const query = qs.toString() ? `?${qs.toString()}` : "";
-  return apiFetch<GamesResponse>(`/api/games${query}`, {
-    signal,
-    next: { revalidate: 3600 },
-  });
+  return apiFetch<GamesResponse>(`/api/games${query}`, { signal });
 }
 
 /** Homepage discovery rows — served from mv_discovery_feeds. */

--- a/scripts/prompts/search-autocomplete-ux-and-perf.md
+++ b/scripts/prompts/search-autocomplete-ux-and-perf.md
@@ -1,0 +1,88 @@
+# Search Autocomplete: Fix Perceived Gap + Speed Up
+
+## Context
+
+On prod, typing in the header search shows a spinner, the spinner disappears, and *then* (after a visible gap) results appear. The autocomplete also feels slow overall.
+
+Two root causes:
+
+1. **Spurious watchdog in `frontend/components/layout/SearchAutocomplete.tsx:104-109`.** A 3-second `setTimeout` clears `suggestions` and flips `loading=false` even while the real request is still in flight. On a Lambda cold start (easily 3-8 s), the user sees: spinner (3 s) → empty dropdown → results pop in. `apiFetch` already sets `AbortSignal.timeout(8000)` browser-side (`frontend/lib/api.ts:37-45`), so the watchdog is redundant *and* harmful — it resolves into stale component state before the real abort fires.
+
+2. **No client-side reuse, heavy payload, and no reachable edge cache.** Backspace/retype refetches the same prefix. The response includes fields the dropdown never renders (`estimated_owners`, `estimated_revenue_usd`, `deck_compatibility`, `crawled_at`, the `is_early_access` EXISTS subquery). CloudFront is `CACHING_DISABLED` for `/api/*` by design (`infra/stacks/delivery_stack.py:116`), so `s-maxage` at the API wouldn't reach an edge cache — we fix this at the client and payload layers instead. Any CloudFront behavior change belongs in the broader caching work tracked in `scripts/prompts/game-report-cache-invalidation.md`.
+
+**Goal**: eliminate the "spinner off → empty → results" gap, and cut perceived latency for a given user's repeat prefixes to ~zero. Cross-user edge caching is explicitly out of scope here.
+
+## Design
+
+### 1. `frontend/components/layout/SearchAutocomplete.tsx`
+
+Rewrite the fetch effect (lines 91-128):
+
+- Delete the `setTimeout(..., 3000)` watchdog and its `clearTimeout` calls.
+- Do **not** clear `suggestions` at the start of a new fetch. Keep the previous list visible behind the spinner so the dropdown never flashes empty on re-query. Only clear when `debouncedQuery.length < 2` (already handled at line 93).
+- Add an in-memory LRU cache at the component top:
+  ```ts
+  const cacheRef = useRef<Map<string, Game[]>>(new Map());
+  ```
+  Key on `query.toLowerCase().trim()`. Before fetching, if the cache has the key, synchronously `setSuggestions` / `setOpen(res.games.length > 0)` / `setLoading(false)` and return without a network call. On successful response, `set` the entry; if `cacheRef.current.size > 20`, delete the oldest entry (Map iteration order = insertion order).
+- Pass `signal` into `getGames(...)` — today the `AbortController` is created but never handed to `apiFetch`, so cancellation is a no-op.
+- Update the call (line 111) to request the compact shape:
+  ```ts
+  getGames({ q: debouncedQuery, limit: 6, sort: "review_count", fields: "compact" }, signal)
+  ```
+
+### 2. `frontend/lib/api.ts`
+
+- `getGames` (lines 111-152): add `fields?: "compact"` to the params type, propagate via `if (params?.fields) qs.set("fields", params.fields);`.
+- Remove the inert `next: { revalidate: 3600 }` (line 150) — it has no effect on client-component fetches and is misleading.
+
+### 3. `src/lambda-functions/lambda_functions/api/handler.py`
+
+**`list_games` handler (lines 119-183):**
+- Add a `fields: str | None = None` query parameter.
+- When `fields == "compact"`, project each returned game dict down to `{appid, name, slug, header_image, review_count, positive_pct, review_score_desc}` before serializing. Do this in the handler, not the repo — one SQL path stays. Rationale: profile the edge-case SQL narrowing (the `EXISTS is_early_access` subquery at `src/library-layer/library_layer/repositories/game_repo.py:514`) only if it matters after the payload shrink; defer.
+- Return `JSONResponse(content={"total": total, "games": games}, headers={"Cache-Control": "private, max-age=300"})`. This is a **browser** cache hint — `private` blocks any shared cache (CloudFront is already `CACHING_DISABLED` on `/api/*` anyway), `max-age=300` lets the same tab reuse a response within 5 min on back/forward / Next.js client routing. No edge-caching behavior.
+
+## Sequencing
+
+1. Backend (`handler.py`) first — adding `fields=compact` + `Cache-Control: private` is backward-compatible; existing callers that omit `fields` see identical responses.
+2. Frontend (`api.ts` + `SearchAutocomplete.tsx`) together — watchdog removal, keep-stale, LRU cache, `fields=compact`, and threading `signal` are one coherent edit.
+
+## Critical files
+
+**Edit:**
+- `/Users/iganza/dev/git/saas/steam-pulse/frontend/components/layout/SearchAutocomplete.tsx` — lines 80-128, 111
+- `/Users/iganza/dev/git/saas/steam-pulse/frontend/lib/api.ts` — lines 111-152
+- `/Users/iganza/dev/git/saas/steam-pulse/src/lambda-functions/lambda_functions/api/handler.py` — lines 119-183
+
+**Reference (no changes):**
+- `/Users/iganza/dev/git/saas/steam-pulse/src/library-layer/library_layer/repositories/game_repo.py:376-521` — `list_games` repo method; `ILIKE '%q%'` already uses the trigram GIN index from migration `0051_games_name_trgm_index.sql`.
+- `/Users/iganza/dev/git/saas/steam-pulse/infra/stacks/delivery_stack.py:113-119` — `/api/*` = `CACHING_DISABLED`; confirms why `s-maxage` at the API is not a lever here.
+
+## Verification
+
+**Local — watchdog + stale-keep:**
+1. `cd frontend && npm run dev`; DevTools → Network → throttle to Slow 3G.
+2. Type `half`, wait for results, then type ` life`. Expect: previous 6 results stay visible with spinner overlaid in the icon; no empty flash; results replace in place.
+3. Regression baseline on `main`: same steps show the dropdown collapse to empty at ~3 s, then results appear 1-5 s later.
+
+**Local — LRU cache:**
+1. Type `witcher`, wait for results, backspace to `witch`, retype `er`. Second render of `witcher` should be synchronous: no spinner, no request in DevTools Network.
+2. Confirm cache bound: type 25 distinct 2+-char prefixes in a row; the 26th type of the 1st prefix should refetch (evicted).
+
+**Local — `signal` threads through:**
+1. Type `roguelike` character-by-character quickly. In DevTools Network, earlier requests should appear as `(canceled)` rather than completing.
+
+**Local — browser cache header:**
+1. `curl -sI "http://localhost:8000/api/games?q=elden&limit=6&sort=review_count&fields=compact"` (or whatever the local API URL is) should show `cache-control: private, max-age=300`.
+2. In DevTools Network, re-issuing the same `/api/games?q=elden...` request via forward/back navigation within 5 min should show `(disk cache)` or `(memory cache)`.
+
+## Out of scope
+
+- Any CloudFront behavior change for `/api/games` or `/api/*` — defer to the broader caching decision tracked in `scripts/prompts/game-report-cache-invalidation.md`. That prompt owns `/api/*` policy.
+- A dedicated `/api/search/suggest` endpoint — folded into `/api/games?fields=compact`.
+- Switching the `ILIKE '%q%'` ranking to pg_trgm `similarity()` or to a tsvector/FTS search. The trigram GIN index already accelerates the current query; ranking changes are a separate UX call.
+- Reducing the 300 ms debounce — the LRU cache already makes retype instant.
+- `sessionStorage` / `localStorage` persistence of the LRU.
+- Keyboard nav, a11y, analytics — unchanged.
+- Repo-side SQL projection narrowing — the `EXISTS` subquery is the only real cost; defer until profiling after payload shrink shows it matters.

--- a/src/lambda-functions/lambda_functions/api/handler.py
+++ b/src/lambda-functions/lambda_functions/api/handler.py
@@ -6,7 +6,7 @@ from typing import Annotated, Literal
 import boto3  # type: ignore[import-untyped]
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.parameters import get_parameter
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.responses import JSONResponse
 from library_layer.config import SteamPulseConfig
 from library_layer.events import WaitlistConfirmationMessage
@@ -129,6 +129,7 @@ _COMPACT_GAME_FIELDS = (
 
 @app.get("/api/games")
 async def list_games(
+    response: Response,
     q: str | None = None,
     genre: str | None = None,
     tag: str | None = None,
@@ -145,7 +146,7 @@ async def list_games(
     limit: int = Query(default=24, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
     fields: Literal["compact"] | None = None,
-) -> JSONResponse:
+) -> dict:
     result = _game_repo.list_games(
         q=q,
         genre=genre,
@@ -195,10 +196,8 @@ async def list_games(
     if fields == "compact":
         games = [{k: g.get(k) for k in _COMPACT_GAME_FIELDS} for g in games]
 
-    return JSONResponse(
-        content={"total": total, "has_more": has_more, "games": games},
-        headers={"Cache-Control": "private, max-age=300"},
-    )
+    response.headers["Cache-Control"] = "private, max-age=300"
+    return {"total": total, "has_more": has_more, "games": games}
 
 
 @app.get("/api/games/basics")

--- a/src/lambda-functions/lambda_functions/api/handler.py
+++ b/src/lambda-functions/lambda_functions/api/handler.py
@@ -116,6 +116,17 @@ async def health() -> dict:
     }
 
 
+_COMPACT_GAME_FIELDS = (
+    "appid",
+    "name",
+    "slug",
+    "header_image",
+    "review_count",
+    "positive_pct",
+    "review_score_desc",
+)
+
+
 @app.get("/api/games")
 async def list_games(
     q: str | None = None,
@@ -133,7 +144,8 @@ async def list_games(
     sort: str = "review_count",
     limit: int = Query(default=24, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-) -> dict:
+    fields: Literal["compact"] | None = None,
+) -> JSONResponse:
     result = _game_repo.list_games(
         q=q,
         genre=genre,
@@ -180,7 +192,13 @@ async def list_games(
 
     has_more = (offset + len(games) < total) if total is not None else len(games) == limit
 
-    return {"total": total, "has_more": has_more, "games": games}
+    if fields == "compact":
+        games = [{k: g.get(k) for k in _COMPACT_GAME_FIELDS} for g in games]
+
+    return JSONResponse(
+        content={"total": total, "has_more": has_more, "games": games},
+        headers={"Cache-Control": "private, max-age=300"},
+    )
 
 
 @app.get("/api/games/basics")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -557,6 +557,36 @@ def test_games_complex_filter_full_page(client: TestClient) -> None:
     assert len(data["games"]) == 24
 
 
+def test_games_serializes_datetime_fields(client: TestClient) -> None:
+    """/api/games must serialize datetime columns (last_analyzed, crawled_at) without crashing."""
+    import datetime as dt
+
+    import lambda_functions.api.handler as api_module
+
+    class _DatetimeGameRepo:
+        def ensure_stub(self, appid: int, name: str | None = None) -> None:
+            pass
+
+        def list_games(self, **kwargs: object) -> dict:
+            return {
+                "total": None,
+                "games": [
+                    {
+                        "appid": 1,
+                        "name": "Test",
+                        "last_analyzed": dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.timezone.utc),
+                        "crawled_at": dt.datetime(2026, 1, 2, 12, 0, tzinfo=dt.timezone.utc),
+                    }
+                ],
+            }
+
+    api_module._game_repo = _DatetimeGameRepo()  # type: ignore[assignment]
+    resp = client.get("/api/games")
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "private, max-age=300"
+    assert resp.json()["games"][0]["last_analyzed"].startswith("2026-01-01")
+
+
 def test_waitlist_rejects_invalid_email(client: TestClient) -> None:
     """POST /api/waitlist with a non-email string returns 422."""
     resp = client.post("/api/waitlist", json={"email": "not-an-email"})


### PR DESCRIPTION
Carefully check this PR!!  It implements promt at: scripts/prompts/search-autocomplete-ux-and-perf.md.

Specific things to check:

- **Spinner/results gap fix** — confirm `SearchAutocomplete.tsx` no longer contains the 3s `setTimeout` watchdog. The prior list must remain visible behind the spinner during refetch (no empty-dropdown flash on Slow 3G). Manually test by throttling to Slow 3G, typing `half`, waiting for results, then typing ` life` — previous 6 results should stay visible.
- **AbortController actually cancels** — `getGames(..., signal)` now threads `signal` through. Verify in DevTools Network that rapid typing of `roguelike` shows earlier requests as `(canceled)` rather than completing.
- **LRU cache bounds** — `cacheRef` is capped at 20 entries with insertion-order eviction via `cacheRef.current.keys().next().value`. Confirm the `undefined` guard is correct and there's no memory leak across long sessions.
- **Compact payload shape** — `_COMPACT_GAME_FIELDS` in `handler.py` returns exactly the 7 fields the dropdown renders (`appid, name, slug, header_image, review_count, positive_pct, review_score_desc`). Verify the dropdown still renders correctly with the trimmed payload and that no caller of `/api/games` that omits `fields` sees a regression (existing 37 tests in `tests/test_api.py` pass).
- **Cache-Control header** — `Cache-Control: private, max-age=300` on `/api/games`. `private` was chosen deliberately because `/api/*` is `CACHING_DISABLED` at CloudFront (`infra/stacks/delivery_stack.py:116`); this is a browser-only hint, not an edge-cache change. Cross-user edge caching is out of scope and is owned by `scripts/prompts/game-report-cache-invalidation.md`.
- **Frontend state consistency** — confirm `setLoading(true)` in `handleChange` (line 199, unchanged) doesn't cause a stuck spinner on cache-hit paths; the effect flips it back to `false` within the same render.
- **No new deps** — no `pyproject.toml` or `package.json` changes; `poetry lock` is not needed.