### PR TITLE
feature/game-report-cache-invalidation: cache reports until re-analyzed

### DIFF
--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -1,12 +1,7 @@
 import { revalidateTag } from "next/cache";
 import type { NextRequest } from "next/server";
 
-// Cache-until-changed companion: the revalidate_frontend Lambda POSTs here
-// after every ReportReadyEvent to bust the `game-${appid}` tag, which
-// covers getGameReport / getReviewStats / getBenchmarks in one shot.
-// The 'max' second arg gives stale-while-revalidate semantics — stale
-// served immediately while a fresh fetch fills the cache in the
-// background.
+// 'max' = stale served while a fresh fetch fills the cache in the background.
 export async function POST(req: NextRequest) {
   const expectedToken = process.env.REVALIDATE_TOKEN;
   if (!expectedToken) {

--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -1,0 +1,36 @@
+import { revalidateTag } from "next/cache";
+import type { NextRequest } from "next/server";
+
+// Cache-until-changed companion: the revalidate_frontend Lambda POSTs here
+// after every ReportReadyEvent to bust the `game-${appid}` tag, which
+// covers getGameReport / getReviewStats / getBenchmarks in one shot.
+// The 'max' second arg gives stale-while-revalidate semantics — stale
+// served immediately while a fresh fetch fills the cache in the
+// background.
+export async function POST(req: NextRequest) {
+  const expectedToken = process.env.REVALIDATE_TOKEN;
+  if (!expectedToken) {
+    return Response.json(
+      { ok: false, error: "revalidate_token_unconfigured" },
+      { status: 500 },
+    );
+  }
+  if (req.headers.get("x-revalidate-token") !== expectedToken) {
+    return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ ok: false, error: "bad_json" }, { status: 400 });
+  }
+
+  const appid = (body as { appid?: unknown })?.appid;
+  if (typeof appid !== "number" || !Number.isInteger(appid) || appid <= 0) {
+    return Response.json({ ok: false, error: "bad_appid" }, { status: 400 });
+  }
+
+  revalidateTag(`game-${appid}`, "max");
+  return Response.json({ ok: true, appid, now: Date.now() });
+}

--- a/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
+++ b/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
@@ -75,8 +75,6 @@ interface GameReportClientProps {
   /** Pre-fetched neighbors for the "More games like this" section on
    *  un-analyzed pages. Empty on analyzed pages. */
   relatedAnalyzed?: RelatedAnalyzedGame[];
-  /** Steam-derived stats fetched server-side alongside the report so the
-   *  shared `game-${appid}` cache tag covers both. */
   reviewStats: ReviewStats | null;
   benchmarks: Benchmarks | null;
 }
@@ -133,10 +131,6 @@ export function GameReportClient({
   reviewStats,
   benchmarks,
 }: GameReportClientProps) {
-  // review_stats + benchmarks are server-fetched alongside the report and
-  // passed in as props, so chart data is already present on first paint —
-  // no client fetch, no skeleton flash.
-
   const name = report?.game_name ?? gameName ?? "Game Report";
   const price = isFree ? "Free" : priceUsd ? `$${priceUsd.toFixed(2)}` : "\u2014";
   const primaryGenre = genres?.[0];

--- a/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
+++ b/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import {
   TrendingUp,
@@ -15,17 +14,14 @@ import {
   Users,
 } from "lucide-react";
 import type { GameReport, ReviewStats, Benchmarks, RelatedAnalyzedGame } from "@/lib/types";
-import { getReviewStats, getBenchmarks } from "@/lib/api";
 import { SectionLabel } from "@/components/game/SectionLabel";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
 import {
   SentimentTimeline,
-  SentimentTimelineSkeleton,
   SentimentTimelineStub,
 } from "@/components/game/SentimentTimeline";
 import {
   PlaytimeChart,
-  PlaytimeChartSkeleton,
   computePlaytimeInsight,
 } from "@/components/game/PlaytimeChart";
 import { CompetitiveBenchmark } from "@/components/game/CompetitiveBenchmark";
@@ -79,6 +75,10 @@ interface GameReportClientProps {
   /** Pre-fetched neighbors for the "More games like this" section on
    *  un-analyzed pages. Empty on analyzed pages. */
   relatedAnalyzed?: RelatedAnalyzedGame[];
+  /** Steam-derived stats fetched server-side alongside the report so the
+   *  shared `game-${appid}` cache tag covers both. */
+  reviewStats: ReviewStats | null;
+  benchmarks: Benchmarks | null;
 }
 
 function formatMonth(iso: string): string | null {
@@ -130,51 +130,12 @@ export function GameReportClient({
   revenueEstimateMethod,
   revenueEstimateReason,
   relatedAnalyzed = [],
+  reviewStats,
+  benchmarks,
 }: GameReportClientProps) {
-  const [reviewStats, setReviewStats] = useState<ReviewStats | null>(null);
-  const [benchmarks, setBenchmarks] = useState<Benchmarks | null>(null);
-  const [statsLoading, setStatsLoading] = useState(true);
-
-  useEffect(() => {
-    // Two independent fetches — benchmarks is intentionally decoupled from
-    // statsLoading so a slow benchmarks response never keeps the Sentiment
-    // History / Playtime Sentiment skeletons on screen after review-stats
-    // have already resolved. Reset state at the start of each effect run
-    // so an appid change never briefly shows the previous game's data, and
-    // so a failed fetch clears (rather than preserves) the stale value.
-    // The AbortController cancels the in-flight benchmarks request on
-    // appid change / unmount so rapid navigations don't waste network
-    // cycles (getReviewStats doesn't accept a signal today, so only
-    // benchmarks are aborted — its state update is still gated by
-    // `active`).
-    let active = true;
-    const benchController = new AbortController();
-    setStatsLoading(true);
-    setReviewStats(null);
-    setBenchmarks(null);
-    (async () => {
-      try {
-        const stats = await getReviewStats(appid);
-        if (active) setReviewStats(stats);
-      } catch {
-        // charts simply won't render
-      } finally {
-        if (active) setStatsLoading(false);
-      }
-    })();
-    (async () => {
-      try {
-        const bench = await getBenchmarks(appid, benchController.signal);
-        if (active && bench) setBenchmarks(bench);
-      } catch {
-        // benchmark section simply won't render (includes AbortError)
-      }
-    })();
-    return () => {
-      active = false;
-      benchController.abort();
-    };
-  }, [appid]);
+  // review_stats + benchmarks are server-fetched alongside the report and
+  // passed in as props, so chart data is already present on first paint —
+  // no client fetch, no skeleton flash.
 
   const name = report?.game_name ?? gameName ?? "Game Report";
   const price = isFree ? "Free" : priceUsd ? `$${priceUsd.toFixed(2)}` : "\u2014";
@@ -289,7 +250,7 @@ export function GameReportClient({
           price={price}
           lastAnalyzed={report?.last_analyzed ?? lastAnalyzed ?? null}
           reviewStats={reviewStats}
-          statsLoading={statsLoading}
+          statsLoading={false}
           reviewCrawledAt={reviewCrawledAt}
           reviewsCompletedAt={reviewsCompletedAt}
           metaCrawledAt={metaCrawledAt}
@@ -581,12 +542,7 @@ export function GameReportClient({
             the chart populate over time. Analyzed pages still hide the
             section below the threshold. --- */}
 
-        {statsLoading ? (
-          <section>
-            <SectionLabel>Sentiment History</SectionLabel>
-            <SentimentTimelineSkeleton />
-          </section>
-        ) : showSentimentHistory ? (
+        {showSentimentHistory ? (
           <section>
             <SectionLabel>Sentiment History</SectionLabel>
             <SentimentTimeline timeline={reviewStats!.timeline} />
@@ -604,12 +560,7 @@ export function GameReportClient({
           </section>
         ) : null}
 
-        {statsLoading ? (
-          <section>
-            <SectionLabel>Playtime Sentiment</SectionLabel>
-            <PlaytimeChartSkeleton />
-          </section>
-        ) : showPlaytimeSentiment ? (
+        {showPlaytimeSentiment ? (
           <section>
             <SectionLabel>Playtime Sentiment</SectionLabel>
             <PlaytimeChart

--- a/frontend/app/games/[appid]/[slug]/page.tsx
+++ b/frontend/app/games/[appid]/[slug]/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getGameReport, getRelatedAnalyzedGames } from "@/lib/api";
+import {
+  getBenchmarks,
+  getGameReport,
+  getRelatedAnalyzedGames,
+  getReviewStats,
+} from "@/lib/api";
 import { ApiError } from "@/lib/api";
-import type { RelatedAnalyzedGame } from "@/lib/types";
+import type { Benchmarks, RelatedAnalyzedGame, ReviewStats } from "@/lib/types";
 import { GameReportClient } from "./GameReportClient";
 import { AUTHOR_NAME, ABOUT_URL } from "@/lib/author";
 
@@ -84,6 +89,8 @@ export default async function GameReportPage({ params }: Props) {
   const fallbackImage = `https://cdn.akamai.steamstatic.com/steam/apps/${numericAppid}/header.jpg`;
 
   let report = null;
+  let reviewStats: ReviewStats | null = null;
+  let benchmarks: Benchmarks | null = null;
   let headerImage = fallbackImage;
   let gameData: {
     gameName?: string;
@@ -118,7 +125,17 @@ export default async function GameReportPage({ params }: Props) {
   } = {};
 
   try {
-    const reportData = await getGameReport(numericAppid);
+    // Fetch report + Steam-derived stats together so the data cache stores
+    // them under one shared `game-${appid}` tag and one revalidation
+    // invalidates all three. reviewStats / benchmarks failures are
+    // non-fatal — the chart sections simply won't render.
+    const [reportData, reviewStatsResult, benchmarksResult] = await Promise.all([
+      getGameReport(numericAppid),
+      getReviewStats(numericAppid).catch(() => null),
+      getBenchmarks(numericAppid).catch(() => null),
+    ]);
+    reviewStats = reviewStatsResult;
+    benchmarks = benchmarksResult;
     if (reportData.status === "available" && reportData.report) {
       report = reportData.report;
     }
@@ -348,11 +365,16 @@ export default async function GameReportPage({ params }: Props) {
           revenueEstimateMethod={gameData.revenueEstimateMethod}
           revenueEstimateReason={gameData.revenueEstimateReason}
           relatedAnalyzed={relatedAnalyzed}
+          reviewStats={reviewStats}
+          benchmarks={benchmarks}
         />
       </main>
     </>
   );
 }
 
-// ISR: revalidate every 24 hours
-export const revalidate = 86400;
+// Cache-until-changed: a 1-year ISR window backed by the
+// `game-${appid}` tag. The revalidate_frontend Lambda calls
+// revalidateTag(...) when a new report is published, so the time-based
+// expiry is just a safety net.
+export const revalidate = 31536000;

--- a/frontend/app/games/[appid]/[slug]/page.tsx
+++ b/frontend/app/games/[appid]/[slug]/page.tsx
@@ -125,10 +125,7 @@ export default async function GameReportPage({ params }: Props) {
   } = {};
 
   try {
-    // Fetch report + Steam-derived stats together so the data cache stores
-    // them under one shared `game-${appid}` tag and one revalidation
-    // invalidates all three. reviewStats / benchmarks failures are
-    // non-fatal — the chart sections simply won't render.
+    // Co-fetch under the shared game-${appid} tag; stats failures are non-fatal.
     const [reportData, reviewStatsResult, benchmarksResult] = await Promise.all([
       getGameReport(numericAppid),
       getReviewStats(numericAppid).catch(() => null),
@@ -373,8 +370,5 @@ export default async function GameReportPage({ params }: Props) {
   );
 }
 
-// Cache-until-changed: a 1-year ISR window backed by the
-// `game-${appid}` tag. The revalidate_frontend Lambda calls
-// revalidateTag(...) when a new report is published, so the time-based
-// expiry is just a safety net.
+// 1y safety net; the game-${appid} tag is the real invalidation signal.
 export const revalidate = 31536000;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -97,7 +97,7 @@ export async function getGameReport(appid: number, signal?: AbortSignal): Promis
 }> {
   return apiFetch(`/api/games/${appid}/report`, {
     signal,
-    next: { revalidate: 3600, tags: [`report-${appid}`] },
+    next: { revalidate: 31536000, tags: [`game-${appid}`] },
   });
 }
 
@@ -207,13 +207,16 @@ export async function getTagsGrouped(
 /** GET /api/games/{appid}/review-stats */
 export async function getReviewStats(appid: number): Promise<ReviewStats> {
   return apiFetch<ReviewStats>(`/api/games/${appid}/review-stats`, {
-    next: { revalidate: 3600 },
+    next: { revalidate: 31536000, tags: [`game-${appid}`] },
   });
 }
 
 /** GET /api/games/{appid}/benchmarks */
 export async function getBenchmarks(appid: number, signal?: AbortSignal): Promise<Benchmarks> {
-  return apiFetch<Benchmarks>(`/api/games/${appid}/benchmarks`, { signal });
+  return apiFetch<Benchmarks>(`/api/games/${appid}/benchmarks`, {
+    signal,
+    next: { revalidate: 31536000, tags: [`game-${appid}`] },
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/application_stage.py
+++ b/infra/application_stage.py
@@ -109,6 +109,7 @@ class ApplicationStage(cdk.Stage):
             spoke_results_queue=messaging.spoke_results_queue,
             email_queue=messaging.email_queue,
             cache_invalidation_queue=messaging.cache_invalidation_queue,
+            frontend_revalidation_queue=messaging.frontend_revalidation_queue,
             spoke_crawl_queue_urls=spoke_crawl_queue_urls,
             env=cdk_env,
         )

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -56,6 +56,7 @@ class ComputeStack(cdk.Stack):
         spoke_results_queue: sqs.IQueue,
         email_queue: sqs.IQueue,
         cache_invalidation_queue: sqs.IQueue,
+        frontend_revalidation_queue: sqs.IQueue,
         spoke_crawl_queue_urls: str,
         **kwargs: object,
     ) -> None:
@@ -281,6 +282,14 @@ class ComputeStack(cdk.Stack):
             frontend_handler = "index.handler"
             frontend_runtime = lambda_.Runtime.PYTHON_3_12
 
+        # Shared secret used by /api/revalidate to authenticate webhook calls
+        # from revalidate_frontend. Resolved at deploy time from SSM so rotating
+        # the secret is a parameter update + redeploy, not a code change.
+        revalidate_token_value = ssm.StringParameter.value_for_string_parameter(
+            self,
+            f"/steampulse/{env}/frontend/revalidate-token",
+        )
+
         frontend_fn = lambda_.Function(
             self,
             "FrontendFn",
@@ -313,6 +322,7 @@ class ComputeStack(cdk.Stack):
                 # with a `local` fallback for dev synth.
                 "CACHE_BUCKET_KEY_PREFIX": f"cache/{self.node.try_get_context('build-id') or 'local'}/",
                 "CACHE_DYNAMO_TABLE": opennext_cache_table.table_name,
+                "REVALIDATE_TOKEN": revalidate_token_value,
             },
         )
         cdk.Tags.of(frontend_fn).add("steampulse:service", "frontend")
@@ -888,6 +898,70 @@ class ComputeStack(cdk.Stack):
             event_sources.SqsEventSource(
                 email_queue,
                 batch_size=1,
+                report_batch_item_failures=True,
+            )
+        )
+
+        # ── Revalidate-Frontend Lambda (SQS → POST /api/revalidate) ─────────────
+        # Drains frontend_revalidation_queue (one report-ready per message),
+        # POSTs the Next.js /api/revalidate route with a shared-secret token,
+        # which calls revalidateTag(`game-${appid}`, 'max') in the OpenNext
+        # data cache. No VPC, no DB — pure outbound HTTPS to the frontend
+        # Lambda's Function URL.
+        revalidate_token_param = (
+            f"/steampulse/{env}/frontend/revalidate-token"
+        )
+        revalidate_role = iam.Role(
+            self,
+            "RevalidateFrontendRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaSQSQueueExecutionRole",
+                ),
+            ],
+        )
+        revalidate_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["ssm:GetParameter"],
+                resources=[
+                    f"arn:aws:ssm:{self.region}:{self.account}"
+                    f":parameter{revalidate_token_param}"
+                ],
+            )
+        )
+        revalidate_fn = PythonFunction(
+            self,
+            "RevalidateFrontendFn",
+            entry="src/lambda-functions",
+            index="lambda_functions/revalidate_frontend/handler.py",
+            handler="handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            layers=[library_layer],
+            role=revalidate_role,
+            timeout=cdk.Duration.seconds(30),
+            memory_size=256,
+            log_group=logs.LogGroup(
+                self,
+                "RevalidateFrontendLogs",
+                log_group_name=f"/steampulse/{env}/revalidate-frontend",
+                retention=logs.RetentionDays.ONE_WEEK,
+                removal_policy=cdk.RemovalPolicy.DESTROY,
+            ),
+            environment=config.to_lambda_env(
+                POWERTOOLS_SERVICE_NAME="revalidate-frontend",
+                POWERTOOLS_METRICS_NAMESPACE="SteamPulse",
+                FRONTEND_BASE_URL=self.frontend_fn_url.url,
+                REVALIDATE_TOKEN_PARAM=revalidate_token_param,
+            ),
+        )
+        cdk.Tags.of(revalidate_fn).add("steampulse:service", "frontend")
+        cdk.Tags.of(revalidate_fn).add("steampulse:tier", "standard")
+        revalidate_fn.add_event_source(
+            event_sources.SqsEventSource(
+                frontend_revalidation_queue,
+                batch_size=10,
+                max_batching_window=cdk.Duration.seconds(5),
                 report_batch_item_failures=True,
             )
         )

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -282,9 +282,7 @@ class ComputeStack(cdk.Stack):
             frontend_handler = "index.handler"
             frontend_runtime = lambda_.Runtime.PYTHON_3_12
 
-        # Shared secret used by /api/revalidate to authenticate webhook calls
-        # from revalidate_frontend. Resolved at deploy time from SSM so rotating
-        # the secret is a parameter update + redeploy, not a code change.
+        # Shared secret /api/revalidate verifies; rotate via SSM + redeploy.
         revalidate_token_value = ssm.StringParameter.value_for_string_parameter(
             self,
             f"/steampulse/{env}/frontend/revalidate-token",
@@ -903,11 +901,6 @@ class ComputeStack(cdk.Stack):
         )
 
         # ── Revalidate-Frontend Lambda (SQS → POST /api/revalidate) ─────────────
-        # Drains frontend_revalidation_queue (one report-ready per message),
-        # POSTs the Next.js /api/revalidate route with a shared-secret token,
-        # which calls revalidateTag(`game-${appid}`, 'max') in the OpenNext
-        # data cache. No VPC, no DB — pure outbound HTTPS to the frontend
-        # Lambda's Function URL.
         revalidate_token_param = (
             f"/steampulse/{env}/frontend/revalidate-token"
         )
@@ -960,7 +953,8 @@ class ComputeStack(cdk.Stack):
         revalidate_fn.add_event_source(
             event_sources.SqsEventSource(
                 frontend_revalidation_queue,
-                batch_size=10,
+                # Serial handler + 5s POST timeout — keep within 30s Lambda budget.
+                batch_size=2,
                 max_batching_window=cdk.Duration.seconds(5),
                 report_batch_item_failures=True,
             )

--- a/infra/stacks/messaging_stack.py
+++ b/infra/stacks/messaging_stack.py
@@ -69,6 +69,11 @@ class MessagingStack(cdk.Stack):
             "EmailDlq",
             retention_period=cdk.Duration.days(14),
         )
+        self.frontend_revalidation_dlq = sqs.Queue(
+            self,
+            "FrontendRevalidationDlq",
+            retention_period=cdk.Duration.days(14),
+        )
         # Deterministic names — spokes in other regions construct ARN/URL
         # strings from these names (CDK tokens can't cross regions).
         self.app_crawl_queue = sqs.Queue(
@@ -129,6 +134,17 @@ class MessagingStack(cdk.Stack):
                 queue=self.email_dlq,
             ),
         )
+        # Frontend cache invalidation — fed by ReportReadyEvent, drained by
+        # revalidate_frontend Lambda which POSTs /api/revalidate.
+        self.frontend_revalidation_queue = sqs.Queue(
+            self,
+            "FrontendRevalidationQueue",
+            visibility_timeout=cdk.Duration.minutes(2),
+            dead_letter_queue=sqs.DeadLetterQueue(
+                max_receive_count=3,
+                queue=self.frontend_revalidation_dlq,
+            ),
+        )
 
         # ── Tags ────────────────────────────────────────────────────────────
         for q in (
@@ -149,6 +165,9 @@ class MessagingStack(cdk.Stack):
             cdk.Tags.of(q).add("steampulse:service", "batch")
 
         for q in (self.cache_invalidation_queue, self.cache_invalidation_dlq):
+            cdk.Tags.of(q).add("steampulse:service", "frontend")
+
+        for q in (self.frontend_revalidation_queue, self.frontend_revalidation_dlq):
             cdk.Tags.of(q).add("steampulse:service", "frontend")
 
         cdk.Tags.of(self.game_events_topic).add("steampulse:service", "crawler")
@@ -210,6 +229,21 @@ class MessagingStack(cdk.Stack):
                 filter_policy={
                     "event_type": sns.SubscriptionFilter.string_filter(
                         allowlist=["catalog-refresh-complete"],
+                    ),
+                },
+            )
+        )
+
+        # frontend-revalidation-queue ← content-events (report-ready only).
+        # One message per re-analysis; drained by revalidate_frontend Lambda
+        # which POSTs the Next.js /api/revalidate endpoint to bust the
+        # game-${appid} tag.
+        self.content_events_topic.add_subscription(
+            subs.SqsSubscription(
+                self.frontend_revalidation_queue,
+                filter_policy={
+                    "event_type": sns.SubscriptionFilter.string_filter(
+                        allowlist=["report-ready"],
                     ),
                 },
             )
@@ -325,6 +359,18 @@ class MessagingStack(cdk.Stack):
             "EmailDlqArnParam",
             parameter_name=f"/steampulse/{env}/messaging/email-dlq-arn",
             string_value=self.email_dlq.queue_arn,
+        )
+        ssm.StringParameter(
+            self,
+            "FrontendRevalidationQueueArnParam",
+            parameter_name=f"/steampulse/{env}/messaging/frontend-revalidation-queue-arn",
+            string_value=self.frontend_revalidation_queue.queue_arn,
+        )
+        ssm.StringParameter(
+            self,
+            "FrontendRevalidationDlqArnParam",
+            parameter_name=f"/steampulse/{env}/messaging/frontend-revalidation-dlq-arn",
+            string_value=self.frontend_revalidation_dlq.queue_arn,
         )
         # Eligibility threshold SSM param
         ssm.StringParameter(

--- a/infra/stacks/messaging_stack.py
+++ b/infra/stacks/messaging_stack.py
@@ -134,8 +134,7 @@ class MessagingStack(cdk.Stack):
                 queue=self.email_dlq,
             ),
         )
-        # Frontend cache invalidation — fed by ReportReadyEvent, drained by
-        # revalidate_frontend Lambda which POSTs /api/revalidate.
+        # Fed by ReportReadyEvent, drained by revalidate_frontend Lambda.
         self.frontend_revalidation_queue = sqs.Queue(
             self,
             "FrontendRevalidationQueue",
@@ -235,9 +234,6 @@ class MessagingStack(cdk.Stack):
         )
 
         # frontend-revalidation-queue ← content-events (report-ready only).
-        # One message per re-analysis; drained by revalidate_frontend Lambda
-        # which POSTs the Next.js /api/revalidate endpoint to bust the
-        # game-${appid} tag.
         self.content_events_topic.add_subscription(
             subs.SqsSubscription(
                 self.frontend_revalidation_queue,

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -1,15 +1,4 @@
-"""Revalidate-Frontend Lambda — SQS → POST /api/revalidate.
-
-Drains frontend_revalidation_queue (SNS-wrapped ReportReadyEvent), calls
-the Next.js /api/revalidate route on the frontend Lambda's Function URL.
-That route runs `revalidateTag(`game-${appid}`, 'max')`, which busts the
-shared cache tag covering getGameReport / getReviewStats / getBenchmarks
-in one shot.
-
-Idempotent — re-delivering the same message just calls revalidateTag
-again, which is a cheap no-op when nothing is cached. Failures raise so
-SQS retries; persistent failures land on the DLQ.
-"""
+"""SQS consumer that POSTs /api/revalidate to bust the game-${appid} tag."""
 
 import json
 import os
@@ -28,11 +17,21 @@ _REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
     os.environ["REVALIDATE_TOKEN_PARAM"],
     decrypt=True,
 )
-_HTTP_TIMEOUT_SECONDS = 10.0
+_HTTP_TIMEOUT_SECONDS = 5.0
+
+# Lazy-init so connections pool across records and warm invocations.
+_http_client: httpx.Client | None = None
+
+
+def _get_http_client() -> httpx.Client:
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.Client(timeout=_HTTP_TIMEOUT_SECONDS)
+    return _http_client
 
 
 def _extract_appid(record: dict) -> int:
-    """Parse SNS-wrapped ReportReadyEvent body and return the appid."""
+    """Parse the SNS-wrapped ReportReadyEvent body and return the appid."""
     body = json.loads(record["body"])
     inner_raw = body.get("Message", body)
     inner = json.loads(inner_raw) if isinstance(inner_raw, str) else inner_raw
@@ -43,14 +42,13 @@ def _extract_appid(record: dict) -> int:
 
 
 def _post_revalidate(appid: int) -> None:
-    response = httpx.post(
+    response = _get_http_client().post(
         f"{_FRONTEND_BASE_URL}/api/revalidate",
         headers={
             "x-revalidate-token": _REVALIDATE_TOKEN,
             "content-type": "application/json",
         },
         json={"appid": appid},
-        timeout=_HTTP_TIMEOUT_SECONDS,
     )
     response.raise_for_status()
 

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -1,0 +1,76 @@
+"""Revalidate-Frontend Lambda — SQS → POST /api/revalidate.
+
+Drains frontend_revalidation_queue (SNS-wrapped ReportReadyEvent), calls
+the Next.js /api/revalidate route on the frontend Lambda's Function URL.
+That route runs `revalidateTag(`game-${appid}`, 'max')`, which busts the
+shared cache tag covering getGameReport / getReviewStats / getBenchmarks
+in one shot.
+
+Idempotent — re-delivering the same message just calls revalidateTag
+again, which is a cheap no-op when nothing is cached. Failures raise so
+SQS retries; persistent failures land on the DLQ.
+"""
+
+import json
+import os
+
+import httpx
+from aws_lambda_powertools import Logger, Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from aws_lambda_powertools.utilities.parameters import get_parameter
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+logger = Logger(service="revalidate-frontend")
+metrics = Metrics(namespace="SteamPulse", service="revalidate-frontend")
+
+_FRONTEND_BASE_URL: str = os.environ["FRONTEND_BASE_URL"].rstrip("/")
+_REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
+    os.environ["REVALIDATE_TOKEN_PARAM"],
+    decrypt=True,
+)
+_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+def _extract_appid(record: dict) -> int:
+    """Parse SNS-wrapped ReportReadyEvent body and return the appid."""
+    body = json.loads(record["body"])
+    inner_raw = body.get("Message", body)
+    inner = json.loads(inner_raw) if isinstance(inner_raw, str) else inner_raw
+    appid = inner.get("appid")
+    if not isinstance(appid, int):
+        raise ValueError(f"missing/invalid appid in event: {inner!r}")
+    return appid
+
+
+def _post_revalidate(appid: int) -> None:
+    response = httpx.post(
+        f"{_FRONTEND_BASE_URL}/api/revalidate",
+        headers={
+            "x-revalidate-token": _REVALIDATE_TOKEN,
+            "content-type": "application/json",
+        },
+        json={"appid": appid},
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+
+
+@logger.inject_lambda_context(clear_state=True)
+@metrics.log_metrics
+def handler(event: dict, _context: LambdaContext) -> dict:
+    batch_item_failures: list[dict[str, str]] = []
+
+    for record in event.get("Records", []):
+        message_id = record.get("messageId", "")
+        try:
+            appid = _extract_appid(record)
+            _post_revalidate(appid)
+            metrics.add_metric(name="RevalidationsSucceeded", unit=MetricUnit.Count, value=1)
+            logger.info("Revalidated", extra={"appid": appid})
+        except Exception:
+            logger.exception("Failed to revalidate", extra={"message_id": message_id})
+            metrics.add_metric(name="RevalidationsFailed", unit=MetricUnit.Count, value=1)
+            if message_id:
+                batch_item_failures.append({"itemIdentifier": message_id})
+
+    return {"batchItemFailures": batch_item_failures}

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -1,0 +1,195 @@
+"""Tests for revalidate_frontend handler — SQS → POST /api/revalidate."""
+
+import json
+import os
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+from pytest_httpx import HTTPXMock
+
+from tests.conftest import MockLambdaContext
+
+_FRONTEND_BASE_URL = "https://frontend.example.lambda-url.us-west-2.on.aws"
+_REVALIDATE_TOKEN_PARAM = "/steampulse/test/frontend/revalidate-token"
+_TOKEN = "test-token-abc123"
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> None:
+    """Force re-import so module-level SSM lookup runs under moto."""
+    import sys
+
+    sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
+    sys.modules.pop("lambda_functions.revalidate_frontend", None)
+
+
+@pytest.fixture(autouse=True)
+def _env() -> None:
+    os.environ["FRONTEND_BASE_URL"] = _FRONTEND_BASE_URL
+    os.environ["REVALIDATE_TOKEN_PARAM"] = _REVALIDATE_TOKEN_PARAM
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+def _seed_ssm() -> None:
+    ssm = boto3.client("ssm", region_name="us-east-1")
+    ssm.put_parameter(
+        Name=_REVALIDATE_TOKEN_PARAM,
+        Value=_TOKEN,
+        Type="String",
+        Overwrite=True,
+    )
+
+
+def _get_module() -> Any:
+    """Re-seed SSM and reset the lazy http client between tests."""
+    _seed_ssm()
+    import lambda_functions.revalidate_frontend.handler as h
+
+    h._http_client = None
+    return h
+
+
+def _sns_wrapped_event(appid: int, message_id: str = "msg-1") -> dict:
+    """Build an SQS record whose body is the SNS notification envelope."""
+    inner = {"event_type": "report-ready", "appid": appid, "game_name": "Test"}
+    body = {
+        "Type": "Notification",
+        "TopicArn": "arn:aws:sns:us-east-1:123:content-events",
+        "Message": json.dumps(inner),
+    }
+    return {
+        "Records": [
+            {
+                "messageId": message_id,
+                "body": json.dumps(body),
+                "receiptHandle": "receipt",
+            }
+        ],
+    }
+
+
+def _multi_record_event(records: list[tuple[int, str]]) -> dict:
+    """Build a multi-record event from [(appid, message_id), ...]."""
+    return {
+        "Records": [
+            {
+                "messageId": message_id,
+                "body": json.dumps(
+                    {
+                        "Type": "Notification",
+                        "Message": json.dumps(
+                            {"event_type": "report-ready", "appid": appid}
+                        ),
+                    }
+                ),
+                "receiptHandle": "receipt",
+            }
+            for appid, message_id in records
+        ],
+    }
+
+
+@mock_aws
+def test_happy_path_posts_revalidate_with_token_and_appid(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 12345, "now": 0},
+    )
+    handler = _get_module()
+    result = handler.handler(_sns_wrapped_event(12345), MockLambdaContext())
+
+    assert result == {"batchItemFailures": []}
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+    req = requests[0]
+    assert req.headers["x-revalidate-token"] == _TOKEN
+    assert json.loads(req.content) == {"appid": 12345}
+
+
+@mock_aws
+def test_non_2xx_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        status_code=500,
+        json={"ok": False, "error": "boom"},
+    )
+    handler = _get_module()
+    result = handler.handler(_sns_wrapped_event(99, message_id="msg-99"), MockLambdaContext())
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "msg-99"}]}
+
+
+@mock_aws
+def test_missing_appid_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
+    handler = _get_module()
+    bad_event = {
+        "Records": [
+            {
+                "messageId": "bad-1",
+                "body": json.dumps(
+                    {
+                        "Type": "Notification",
+                        "Message": json.dumps({"event_type": "report-ready"}),
+                    }
+                ),
+                "receiptHandle": "r",
+            }
+        ],
+    }
+    result = handler.handler(bad_event, MockLambdaContext())
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "bad-1"}]}
+    # No HTTP call attempted when appid extraction fails.
+    assert httpx_mock.get_requests() == []
+
+
+@mock_aws
+def test_partial_batch_failure_only_reports_failed_record(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 1, "now": 0},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        status_code=502,
+        json={"ok": False},
+    )
+    handler = _get_module()
+    result = handler.handler(
+        _multi_record_event([(1, "ok-msg"), (2, "fail-msg")]),
+        MockLambdaContext(),
+    )
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "fail-msg"}]}
+
+
+@mock_aws
+def test_unwrapped_sqs_body_also_parses(httpx_mock: HTTPXMock) -> None:
+    """Defensive path: direct SQS message with no SNS wrapping still parses."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 7, "now": 0},
+    )
+    handler = _get_module()
+    direct_event = {
+        "Records": [
+            {
+                "messageId": "direct-1",
+                "body": json.dumps({"event_type": "report-ready", "appid": 7}),
+                "receiptHandle": "r",
+            }
+        ],
+    }
+    result = handler.handler(direct_event, MockLambdaContext())
+
+    assert result == {"batchItemFailures": []}
+    assert len(httpx_mock.get_requests()) == 1

--- a/tests/infra/test_compute_stack.py
+++ b/tests/infra/test_compute_stack.py
@@ -38,6 +38,7 @@ def template() -> assertions.Template:
     spoke_results_queue = sqs.Queue(stack, "SpokeResultsQueue")
     email_queue = sqs.Queue(stack, "EmailQueue")
     cache_invalidation_queue = sqs.Queue(stack, "CacheInvalidationQueue")
+    frontend_revalidation_queue = sqs.Queue(stack, "FrontendRevalidationQueue")
 
     config = SteamPulseConfig(
         ENVIRONMENT="production",
@@ -70,6 +71,7 @@ def template() -> assertions.Template:
         spoke_results_queue=spoke_results_queue,
         email_queue=email_queue,
         cache_invalidation_queue=cache_invalidation_queue,
+        frontend_revalidation_queue=frontend_revalidation_queue,
         spoke_crawl_queue_urls="https://sqs.us-east-1.amazonaws.com/123456789012/steampulse-spoke-crawl-us-east-1-production",
     )
     return assertions.Template.from_stack(compute)

--- a/tests/infra/test_messaging_stack.py
+++ b/tests/infra/test_messaging_stack.py
@@ -49,10 +49,11 @@ def test_messaging_stack_creates_3_topics() -> None:
 def test_messaging_stack_creates_subscriptions_with_filters() -> None:
     """SNS subscriptions use event_type filter policies (test 45)."""
     template = _synth_messaging_stack()
-    # 4 subscriptions: metadata-enrichment, review-crawl ($or CfnSubscription),
-    # batch-staging, cache-invalidation (catalog-refresh-complete only).
+    # 5 subscriptions: metadata-enrichment, review-crawl ($or CfnSubscription),
+    # batch-staging, cache-invalidation (catalog-refresh-complete only),
+    # frontend-revalidation (report-ready).
     subs = template.find_resources("AWS::SNS::Subscription")
-    assert len(subs) == 4, f"Expected 4 subscriptions, got {len(subs)}"
+    assert len(subs) == 5, f"Expected 5 subscriptions, got {len(subs)}"
 
     # Every subscription must have a FilterPolicy
     for logical_id, resource in subs.items():


### PR DESCRIPTION
Carefully check this PR!!  It implements promt at: scripts/prompts/game-report-cache-invalidation.md.

Specific things to verify:
- **New SSM param required pre-deploy**: `/steampulse/{env}/frontend/revalidate-token` must exist before `cdk deploy` — `compute_stack.py` resolves it at synth/deploy time for `FrontendFn` env (`REVALIDATE_TOKEN`) and the `RevalidateFrontendFn` reads it via `REVALIDATE_TOKEN_PARAM`. Deploy will fail if the param is missing.
- **Webhook target is the Function URL, not CloudFront**: `RevalidateFrontendFn` calls `${FRONTEND_BASE_URL}/api/revalidate` where `FRONTEND_BASE_URL = self.frontend_fn_url.url`. This bypasses CloudFront's `/api/*` → FastAPI route, which would otherwise 404 the revalidate POST.
- **CloudFront-edge invalidation NOT covered**: design only invalidates the Next.js OpenNext data cache. With `revalidate=31536000` and OpenNext emitting `s-maxage=31536000`, CloudFront could hold stale HTML at the edge until the next SWR boundary. `scripts/invalidate-cdn.sh` remains the manual escape hatch — confirm whether staging behavior is acceptable before relying on it in production.
- **Unified cache tag**: `getGameReport`, `getReviewStats`, `getBenchmarks` now all use `tags: ['game-${appid}']`. A single `revalidateTag('game-${appid}', 'max')` call busts all three. The previous `report-${appid}` tag is gone — confirm nothing else in the codebase referenced it.
- **Server-side fetch shape changed**: `page.tsx` does `Promise.all([getGameReport, getReviewStats, getBenchmarks])` server-side and passes results as props. `reviewStats`/`benchmarks` failures resolve to `null` so the chart sections simply don't render. Check that no client component still expects to fetch them.
- **`useEffect` removed from `GameReportClient`**: along with `statsLoading`. Skeletons (`SentimentTimelineSkeleton`, `PlaytimeChartSkeleton`) are no longer rendered. `QuickStats` still gets `statsLoading={false}` — verify it doesn't depend on the loading branch.
- **New SQS subscription**: `frontend_revalidation_queue` joins `content_events_topic` with filter `event_type=report-ready`. Subscription count assertion in `tests/infra/test_messaging_stack.py` bumped 4→5.
- **Lambda is non-VPC, no DB**: only outbound HTTPS to the frontend Function URL + SSM read. DLQ + 3 retries via SQS.