### PR TITLE
feature/opennext-revalidation-pipeline: add queue + consumer Lambda

### DIFF
--- a/docs/frontend-data-flow.txt
+++ b/docs/frontend-data-flow.txt
@@ -117,11 +117,21 @@
   FrontendFn  /api/revalidate route
     │  verify x-revalidate-token == REVALIDATE_TOKEN env
     │  revalidateTag(`game-${appid}`, "max")
-    │   └─ "max" gives stale-while-revalidate semantics: stale served
-    │      immediately while a fresh fetch fills the cache in background
+    │   └─ "max" gives stale-while-revalidate semantics: next request
+    │      gets the stale entry immediately and triggers a background
+    │      re-render via the OpenNext revalidation queue
     ▼
   OpenNext data cache (S3 + DynamoDB)
-    │  next request for /games/${appid}/* re-renders from fresh API data
+    │  next request to /games/${appid}/* → cache returns STALE entry
+    │  AND publishes a re-render request to OpenNextRevalidationQueue
+    ▼
+  SQS  OpenNextRevalidationQueue   (DLQ after 3 retries)
+    │
+    ▼
+  OpenNextRevalidationFn  (batch_size=5, reserved_concurrency=5)
+    │  re-renders the page server-side using the same FastAPI fetches
+    │  writes the fresh entry back to S3 + DynamoDB
+    │  subsequent requests now return HIT with fresh content
     ▼
   CloudFront edge HTML cache  ⚠ NOT INVALIDATED by this loop
     Tracked in scripts/prompts/game-report-cloudfront-invalidation.md.
@@ -152,10 +162,18 @@
             never exposed to browser
     REVALIDATE_TOKEN  ← SSM /steampulse/{env}/frontend/revalidate-token
         └── verified by /api/revalidate route handler
+    REVALIDATION_QUEUE_URL    = OpenNextRevalidationQueue URL
+    REVALIDATION_QUEUE_REGION = self.region
+        └── OpenNext enqueues re-render requests here when serving STALE
 
-  RevalidateFrontendFn (SQS consumer)
+  RevalidateFrontendFn (SQS consumer of report-ready events)
     FRONTEND_BASE_URL       = FrontendFn Function URL  (bypasses CloudFront)
     REVALIDATE_TOKEN_PARAM  = SSM path read at cold start
+
+  OpenNextRevalidationFn (SQS consumer of stale-page re-render requests)
+    API_URL                  = same as FrontendFn
+    CACHE_BUCKET_*           = same as FrontendFn (writes refreshed entries)
+    CACHE_DYNAMO_TABLE       = same as FrontendFn
 
   Browser JS
     NEXT_PUBLIC_API_URL = ""   (same-origin, CloudFront handles routing)

--- a/docs/frontend-data-flow.txt
+++ b/docs/frontend-data-flow.txt
@@ -47,36 +47,86 @@
 
 
 ╔══════════════════════════════════════════════════════════════════════╗
-║                     ISR CACHE FLOW (OpenNext)                        ║
+║       ISR CACHE FLOW — cache-until-changed (game report pages)       ║
 ╚══════════════════════════════════════════════════════════════════════╝
 
   Browser
-    │  GET /games/440/team-fortress-2-440
+    │  GET /games/3205380/omelet-you-cook-3205380
     ▼
-  CloudFront
-    │
+  CloudFront  (s-maxage=31536000 from origin → edge caches for 1y
+    │                                          or until manual invalidation)
+    │   miss?
     ▼
-  Next.js Lambda
+  Next.js Lambda (FrontendFn)
     │
-    ├─── Check S3 cache (steampulse-assets-staging/cache/)
-    │         hit? ──► serve cached HTML  ──► Browser
-    │         miss?
+    ├─── Check S3 cache (steampulse-frontend-{env}/cache/{BUILD_ID}/)
+    │         hit?  ─► serve cached HTML ─► CloudFront ─► Browser
+    │         miss / tag-invalidated?
     │              │
-    │              ├─── Check DynamoDB (steampulse-opennext-cache-staging)
+    │              ├─── Check DynamoDB (OpenNextCacheTable)
     │              │    GSI: revalidate (path + revalidatedAt)
-    │              │    "has this path been tag-invalidated?"
+    │              │    "has the game-${appid} tag been busted since
+    │              │     this entry was written?"
     │              │
     │              ▼
-    │         fetch(API_URL + "/api/games/440/report")
+    │         Promise.all([
+    │           fetch(API_URL + "/api/games/${appid}/report"),
+    │           fetch(API_URL + "/api/games/${appid}/review-stats"),
+    │           fetch(API_URL + "/api/games/${appid}/benchmarks"),
+    │         ])  — all three tagged `game-${appid}`
     │              │
     │              ▼
     │         FastAPI Lambda ──► RDS ──► JSON
     │              │
-    │         render HTML
+    │         render HTML (server component)
     │              │
-    │         write to S3 cache  (TTL: revalidate = 3600s)
+    │         write to S3 cache  (revalidate = 31536000s — 1y safety net;
+    │                             tag is the real invalidation signal)
     │              │
-    └─────────────►│──► Browser
+    └─────────────►│──► CloudFront ──► Browser
+
+  Footgun (Next.js 16): dynamic-segment routes ([appid]/[slug]) only honor
+    `export const revalidate` when the page also exports `generateStaticParams`
+    (an empty array `() => []` is enough). Without it the route is treated
+    as fully dynamic SSR — every request hits the API, and `revalidateTag`
+    has nothing to invalidate. See app/games/[appid]/[slug]/page.tsx.
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║      TAG INVALIDATION (cache-until-changed write path)               ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  AnalysisFn  (Step Functions task — runs after every re-analysis)
+    │  publish ReportReadyEvent { event_type: "report-ready", appid, … }
+    ▼
+  SNS  content_events_topic
+    │   filter: event_type = "report-ready"
+    ▼
+  SQS  frontend_revalidation_queue   (DLQ after 3 retries)
+    │
+    ▼
+  RevalidateFrontendFn  (batch_size=2, 5s POST timeout, 30s Lambda budget)
+    │  POST {FRONTEND_BASE_URL}/api/revalidate
+    │  headers: x-revalidate-token: <SSM /steampulse/{env}/frontend/revalidate-token>
+    │  body:    { "appid": <int> }
+    │
+    │  IMPORTANT: FRONTEND_BASE_URL is the FrontendFn Function URL, not
+    │  CloudFront. The /api/* CloudFront behaviour routes to FastAPI, so
+    │  going through CloudFront would 404.
+    ▼
+  FrontendFn  /api/revalidate route
+    │  verify x-revalidate-token == REVALIDATE_TOKEN env
+    │  revalidateTag(`game-${appid}`, "max")
+    │   └─ "max" gives stale-while-revalidate semantics: stale served
+    │      immediately while a fresh fetch fills the cache in background
+    ▼
+  OpenNext data cache (S3 + DynamoDB)
+    │  next request for /games/${appid}/* re-renders from fresh API data
+    ▼
+  CloudFront edge HTML cache  ⚠ NOT INVALIDATED by this loop
+    Tracked in scripts/prompts/game-report-cloudfront-invalidation.md.
+    Until that lands, CloudFront edges hold stale HTML up to s-maxage
+    (1 year). Manual flush: scripts/invalidate-cdn.sh.
 
 
 ╔══════════════════════════════════════════════════════════════════════╗
@@ -100,6 +150,12 @@
         │
         └── used only server-side (SSR)
             never exposed to browser
+    REVALIDATE_TOKEN  ← SSM /steampulse/{env}/frontend/revalidate-token
+        └── verified by /api/revalidate route handler
+
+  RevalidateFrontendFn (SQS consumer)
+    FRONTEND_BASE_URL       = FrontendFn Function URL  (bypasses CloudFront)
+    REVALIDATE_TOKEN_PARAM  = SSM path read at cold start
 
   Browser JS
     NEXT_PUBLIC_API_URL = ""   (same-origin, CloudFront handles routing)

--- a/frontend/app/games/[appid]/[slug]/page.tsx
+++ b/frontend/app/games/[appid]/[slug]/page.tsx
@@ -372,3 +372,9 @@ export default async function GameReportPage({ params }: Props) {
 
 // 1y safety net; the game-${appid} tag is the real invalidation signal.
 export const revalidate = 31536000;
+
+// Empty list opts the route into on-demand ISR — Next 16 won't treat the
+// dynamic segments as pure SSR and will honor the `revalidate` window above.
+export async function generateStaticParams() {
+  return [];
+}

--- a/infra/application_stage.py
+++ b/infra/application_stage.py
@@ -110,6 +110,7 @@ class ApplicationStage(cdk.Stage):
             email_queue=messaging.email_queue,
             cache_invalidation_queue=messaging.cache_invalidation_queue,
             frontend_revalidation_queue=messaging.frontend_revalidation_queue,
+            opennext_revalidation_queue=messaging.opennext_revalidation_queue,
             spoke_crawl_queue_urls=spoke_crawl_queue_urls,
             env=cdk_env,
         )

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -339,6 +339,11 @@ class ComputeStack(cdk.Stack):
         )
 
         # ── OpenNext Revalidation Lambda (drains stale-page re-render queue) ──
+        if not os.path.isdir(_OPEN_NEXT_REVALIDATION):
+            raise FileNotFoundError(
+                f"OpenNext revalidation bundle missing at {_OPEN_NEXT_REVALIDATION}. "
+                "Run `cd frontend && npm run build:open-next` before cdk synth/deploy."
+            )
         opennext_revalidation_fn = lambda_.Function(
             self,
             "OpenNextRevalidationFn",

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -36,6 +36,7 @@ _PLACEHOLDER_HANDLER = (
     "'body': '<h1>Frontend not yet deployed</h1>'}"
 )
 _OPEN_NEXT_SERVER = "frontend/.open-next/server-functions/default"
+_OPEN_NEXT_REVALIDATION = "frontend/.open-next/revalidation-function"
 
 
 class ComputeStack(cdk.Stack):
@@ -57,6 +58,7 @@ class ComputeStack(cdk.Stack):
         email_queue: sqs.IQueue,
         cache_invalidation_queue: sqs.IQueue,
         frontend_revalidation_queue: sqs.IQueue,
+        opennext_revalidation_queue: sqs.IQueue,
         spoke_crawl_queue_urls: str,
         **kwargs: object,
     ) -> None:
@@ -321,6 +323,8 @@ class ComputeStack(cdk.Stack):
                 "CACHE_BUCKET_KEY_PREFIX": f"cache/{self.node.try_get_context('build-id') or 'local'}/",
                 "CACHE_DYNAMO_TABLE": opennext_cache_table.table_name,
                 "REVALIDATE_TOKEN": revalidate_token_value,
+                "REVALIDATION_QUEUE_URL": opennext_revalidation_queue.queue_url,
+                "REVALIDATION_QUEUE_REGION": self.region,
             },
         )
         cdk.Tags.of(frontend_fn).add("steampulse:service", "frontend")
@@ -328,9 +332,49 @@ class ComputeStack(cdk.Stack):
 
         frontend_bucket.grant_read_write(frontend_fn)
         opennext_cache_table.grant_read_write_data(frontend_fn)
+        opennext_revalidation_queue.grant_send_messages(frontend_fn)
 
         self.frontend_fn_url = frontend_fn.add_function_url(
             auth_type=lambda_.FunctionUrlAuthType.NONE,
+        )
+
+        # ── OpenNext Revalidation Lambda (drains stale-page re-render queue) ──
+        opennext_revalidation_fn = lambda_.Function(
+            self,
+            "OpenNextRevalidationFn",
+            runtime=lambda_.Runtime.NODEJS_22_X,
+            handler="index.handler",
+            code=lambda_.Code.from_asset(_OPEN_NEXT_REVALIDATION),
+            memory_size=512,
+            timeout=cdk.Duration.minutes(2),
+            reserved_concurrent_executions=5,
+            log_group=logs.LogGroup(
+                self,
+                "OpenNextRevalidationLogs",
+                log_group_name=f"/steampulse/{env}/opennext-revalidation",
+                retention=logs.RetentionDays.ONE_WEEK,
+                removal_policy=cdk.RemovalPolicy.DESTROY,
+            ),
+            environment={
+                "NODE_ENV": "production",
+                "API_URL": self.api_fn_url.url,
+                "CACHE_BUCKET_NAME": frontend_bucket.bucket_name,
+                "CACHE_BUCKET_REGION": self.region,
+                "CACHE_BUCKET_KEY_PREFIX": f"cache/{self.node.try_get_context('build-id') or 'local'}/",
+                "CACHE_DYNAMO_TABLE": opennext_cache_table.table_name,
+            },
+        )
+        cdk.Tags.of(opennext_revalidation_fn).add("steampulse:service", "frontend")
+        cdk.Tags.of(opennext_revalidation_fn).add("steampulse:tier", "critical")
+        frontend_bucket.grant_read_write(opennext_revalidation_fn)
+        opennext_cache_table.grant_read_write_data(opennext_revalidation_fn)
+        opennext_revalidation_fn.add_event_source(
+            event_sources.SqsEventSource(
+                opennext_revalidation_queue,
+                batch_size=5,
+                max_batching_window=cdk.Duration.seconds(2),
+                report_batch_item_failures=True,
+            )
         )
 
         # ── Crawler Lambda ────────────────────────────────────────────────────

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -339,9 +339,10 @@ class ComputeStack(cdk.Stack):
         )
 
         # ── OpenNext Revalidation Lambda (drains stale-page re-render queue) ──
-        if not os.path.isdir(_OPEN_NEXT_REVALIDATION):
+        if not os.path.isfile(os.path.join(_OPEN_NEXT_REVALIDATION, "index.mjs")):
             raise FileNotFoundError(
-                f"OpenNext revalidation bundle missing at {_OPEN_NEXT_REVALIDATION}. "
+                f"OpenNext revalidation bundle missing or incomplete at "
+                f"{_OPEN_NEXT_REVALIDATION} (no index.mjs). "
                 "Run `cd frontend && npm run build:open-next` before cdk synth/deploy."
             )
         opennext_revalidation_fn = lambda_.Function(

--- a/infra/stacks/messaging_stack.py
+++ b/infra/stacks/messaging_stack.py
@@ -74,6 +74,11 @@ class MessagingStack(cdk.Stack):
             "FrontendRevalidationDlq",
             retention_period=cdk.Duration.days(14),
         )
+        self.opennext_revalidation_dlq = sqs.Queue(
+            self,
+            "OpenNextRevalidationDlq",
+            retention_period=cdk.Duration.days(14),
+        )
         # Deterministic names — spokes in other regions construct ARN/URL
         # strings from these names (CDK tokens can't cross regions).
         self.app_crawl_queue = sqs.Queue(
@@ -144,6 +149,16 @@ class MessagingStack(cdk.Stack):
                 queue=self.frontend_revalidation_dlq,
             ),
         )
+        # OpenNext writes here when a stale data-cache entry needs re-rendering.
+        self.opennext_revalidation_queue = sqs.Queue(
+            self,
+            "OpenNextRevalidationQueue",
+            visibility_timeout=cdk.Duration.minutes(5),
+            dead_letter_queue=sqs.DeadLetterQueue(
+                max_receive_count=3,
+                queue=self.opennext_revalidation_dlq,
+            ),
+        )
 
         # ── Tags ────────────────────────────────────────────────────────────
         for q in (
@@ -167,6 +182,9 @@ class MessagingStack(cdk.Stack):
             cdk.Tags.of(q).add("steampulse:service", "frontend")
 
         for q in (self.frontend_revalidation_queue, self.frontend_revalidation_dlq):
+            cdk.Tags.of(q).add("steampulse:service", "frontend")
+
+        for q in (self.opennext_revalidation_queue, self.opennext_revalidation_dlq):
             cdk.Tags.of(q).add("steampulse:service", "frontend")
 
         cdk.Tags.of(self.game_events_topic).add("steampulse:service", "crawler")
@@ -367,6 +385,24 @@ class MessagingStack(cdk.Stack):
             "FrontendRevalidationDlqArnParam",
             parameter_name=f"/steampulse/{env}/messaging/frontend-revalidation-dlq-arn",
             string_value=self.frontend_revalidation_dlq.queue_arn,
+        )
+        ssm.StringParameter(
+            self,
+            "OpenNextRevalidationQueueUrlParam",
+            parameter_name=f"/steampulse/{env}/messaging/opennext-revalidation-queue-url",
+            string_value=self.opennext_revalidation_queue.queue_url,
+        )
+        ssm.StringParameter(
+            self,
+            "OpenNextRevalidationQueueArnParam",
+            parameter_name=f"/steampulse/{env}/messaging/opennext-revalidation-queue-arn",
+            string_value=self.opennext_revalidation_queue.queue_arn,
+        )
+        ssm.StringParameter(
+            self,
+            "OpenNextRevalidationDlqArnParam",
+            parameter_name=f"/steampulse/{env}/messaging/opennext-revalidation-dlq-arn",
+            string_value=self.opennext_revalidation_dlq.queue_arn,
         )
         # Eligibility threshold SSM param
         ssm.StringParameter(

--- a/scripts/prompts/opennext-revalidation-pipeline.md
+++ b/scripts/prompts/opennext-revalidation-pipeline.md
@@ -73,21 +73,22 @@ Deliberately **not** subscribed to any SNS topic — the producer is `FrontendFn
 
 ```python
 _OPEN_NEXT_REVALIDATION = "frontend/.open-next/revalidation-function"
-if os.path.isdir(_OPEN_NEXT_REVALIDATION):
-    revalidation_code = lambda_.Code.from_asset(_OPEN_NEXT_REVALIDATION)
-    revalidation_runtime = lambda_.Runtime.NODEJS_22_X
-else:
-    revalidation_code = lambda_.Code.from_inline(
-        "exports.handler = async () => ({ statusCode: 200 });"
+# Fail loudly if the bundle wasn't built — no placeholder fallback that
+# would silently deploy a stub Lambda. Validates the entrypoint file
+# itself, not just the directory, so a partial/empty build also errors.
+if not os.path.isfile(os.path.join(_OPEN_NEXT_REVALIDATION, "index.mjs")):
+    raise FileNotFoundError(
+        f"OpenNext revalidation bundle missing or incomplete at "
+        f"{_OPEN_NEXT_REVALIDATION} (no index.mjs). "
+        "Run `cd frontend && npm run build:open-next` before cdk synth/deploy."
     )
-    revalidation_runtime = lambda_.Runtime.NODEJS_22_X
 
 opennext_revalidation_fn = lambda_.Function(
     self,
     "OpenNextRevalidationFn",
-    runtime=revalidation_runtime,
+    runtime=lambda_.Runtime.NODEJS_22_X,
     handler="index.handler",
-    code=revalidation_code,
+    code=lambda_.Code.from_asset(_OPEN_NEXT_REVALIDATION),
     memory_size=512,
     timeout=cdk.Duration.minutes(2),
     reserved_concurrent_executions=5,

--- a/scripts/prompts/opennext-revalidation-pipeline.md
+++ b/scripts/prompts/opennext-revalidation-pipeline.md
@@ -1,0 +1,194 @@
+# OpenNext Revalidation Pipeline
+
+## Context
+
+`feature/game-report-cache-invalidation` (PR #130) wired `revalidateTag('game-${appid}', 'max')` into the OpenNext data cache. It works — `RevalidateFrontendFn` is firing, the route handler is calling `revalidateTag`, the tag is being marked invalidated in the OpenNext DynamoDB cache table.
+
+But end-to-end testing on production reveals the cache **never actually refreshes**. Every hit on a previously-cached page returns `x-nextjs-cache: STALE` indefinitely, and the rendered HTML keeps the pre-invalidation `last_analyzed`. CloudWatch logs on `FrontendFn` show why:
+
+```
+ERROR Failed to revalidate stale page /games/3205380/omelet-you-cook-3205380
+QueueDoesNotExist: The specified queue does not exist.
+```
+
+OpenNext's design splits the data cache from the re-render path:
+
+1. Server function checks the data cache. Fresh → serve. Stale → serve stale + **enqueue** a re-render request to an internal SQS queue.
+2. A separate `revalidation-function` Lambda consumes from that queue, re-renders the page, writes the fresh entry back to the data cache.
+
+We provisioned the cache (DynamoDB + S3) but never provisioned (a) the revalidation queue or (b) the `revalidation-function` Lambda. So step 2 throws `QueueDoesNotExist`, the cache entry stays stale forever, and viewers see pre-invalidation HTML.
+
+**Goal**: provision the missing OpenNext revalidation pipeline so that `revalidateTag` actually leads to a re-render. After this lands, the full cache-until-changed loop closes:
+
+- `report-ready` SNS → SQS → `RevalidateFrontendFn` → POST `/api/revalidate` → `revalidateTag(...)` → mark stale in DynamoDB → next hit serves stale **and** enqueues re-render → revalidation Lambda re-renders → next hit after that returns fresh.
+
+**Scope**: just the OpenNext revalidation queue + Lambda + env wiring. Do not touch the existing `RevalidateFrontendFn`, the SNS topic, the `frontend_revalidation_queue`, or the route handler — those are working.
+
+**Non-goal**: CloudFront edge invalidation. Tracked separately in `scripts/prompts/game-report-cloudfront-invalidation.md`.
+
+## Best-practice foundation
+
+- **OpenNext bundle is already built**: `frontend/.open-next/revalidation-function/` exists after `open-next build`. The Lambda only needs an `aws_lambda.Function` pointing at that bundle, plus the right env vars.
+- **OpenNext's expected env var**: the server function reads `REVALIDATION_QUEUE_URL` (and `REVALIDATION_QUEUE_REGION`) at runtime to know where to enqueue. Without those set, it falls back to a default name that doesn't exist → `QueueDoesNotExist`.
+- **Queue config**: long visibility timeout (≥ render budget; matches OpenNext's recommended 60s+), DLQ to surface render failures, FIFO not required (OpenNext deduplicates by path internally).
+- **Concurrency**: revalidation is bursty when many tags invalidate at once (e.g., a re-analyze cycle). `reserved_concurrent_executions` of 5–10 keeps cost bounded; OpenNext's queue tolerates backpressure.
+- **Same env as `FrontendFn`**: revalidation function reads/writes the same OpenNext cache → it needs the same `CACHE_BUCKET_NAME`, `CACHE_BUCKET_REGION`, `CACHE_BUCKET_KEY_PREFIX`, `CACHE_DYNAMO_TABLE`, `API_URL`. Use the same values literally.
+
+## Design
+
+### 1. Messaging — new SQS queue
+
+`infra/stacks/messaging_stack.py`:
+
+```python
+self.opennext_revalidation_dlq = sqs.Queue(
+    self,
+    "OpenNextRevalidationDlq",
+    retention_period=cdk.Duration.days(14),
+)
+self.opennext_revalidation_queue = sqs.Queue(
+    self,
+    "OpenNextRevalidationQueue",
+    visibility_timeout=cdk.Duration.minutes(5),
+    dead_letter_queue=sqs.DeadLetterQueue(
+        max_receive_count=3,
+        queue=self.opennext_revalidation_dlq,
+    ),
+)
+# Tag both with steampulse:service=frontend.
+# Export queue URL + ARN to SSM for the compute stack.
+```
+
+Deliberately **not** subscribed to any SNS topic — the producer is `FrontendFn` itself (via the OpenNext runtime), not an external event source. OpenNext sends messages directly via the AWS SDK.
+
+### 2. Compute — revalidation Lambda + env on FrontendFn
+
+`infra/stacks/compute_stack.py`:
+
+- Accept the new queue as a constructor param: `opennext_revalidation_queue: sqs.IQueue`.
+- After the existing `frontend_fn = lambda_.Function(...)` block:
+  - Grant `frontend_fn.role` permission to send to `opennext_revalidation_queue` (`opennext_revalidation_queue.grant_send_messages(frontend_fn)`).
+  - Add `REVALIDATION_QUEUE_URL` and `REVALIDATION_QUEUE_REGION` to the FrontendFn `environment` dict.
+- Add a new Lambda mirroring the FrontendFn pattern (Node.js 22, no VPC, OpenNext bundle):
+
+```python
+_OPEN_NEXT_REVALIDATION = "frontend/.open-next/revalidation-function"
+if os.path.isdir(_OPEN_NEXT_REVALIDATION):
+    revalidation_code = lambda_.Code.from_asset(_OPEN_NEXT_REVALIDATION)
+    revalidation_runtime = lambda_.Runtime.NODEJS_22_X
+else:
+    revalidation_code = lambda_.Code.from_inline(
+        "exports.handler = async () => ({ statusCode: 200 });"
+    )
+    revalidation_runtime = lambda_.Runtime.NODEJS_22_X
+
+opennext_revalidation_fn = lambda_.Function(
+    self,
+    "OpenNextRevalidationFn",
+    runtime=revalidation_runtime,
+    handler="index.handler",
+    code=revalidation_code,
+    memory_size=512,
+    timeout=cdk.Duration.minutes(2),
+    reserved_concurrent_executions=5,
+    log_group=logs.LogGroup(
+        self,
+        "OpenNextRevalidationLogs",
+        log_group_name=f"/steampulse/{env}/opennext-revalidation",
+        retention=logs.RetentionDays.ONE_WEEK,
+        removal_policy=cdk.RemovalPolicy.DESTROY,
+    ),
+    environment={
+        "NODE_ENV": "production",
+        "API_URL": self.api_fn_url.url,
+        "CACHE_BUCKET_NAME": frontend_bucket.bucket_name,
+        "CACHE_BUCKET_REGION": self.region,
+        "CACHE_BUCKET_KEY_PREFIX": f"cache/{self.node.try_get_context('build-id') or 'local'}/",
+        "CACHE_DYNAMO_TABLE": opennext_cache_table.table_name,
+    },
+)
+frontend_bucket.grant_read_write(opennext_revalidation_fn)
+opennext_cache_table.grant_read_write_data(opennext_revalidation_fn)
+opennext_revalidation_fn.add_event_source(
+    event_sources.SqsEventSource(
+        opennext_revalidation_queue,
+        batch_size=5,
+        max_batching_window=cdk.Duration.seconds(2),
+        report_batch_item_failures=True,
+    )
+)
+```
+
+Tag the function with `steampulse:service=frontend`, `steampulse:tier=critical` (a stuck revalidation queue means stale pages forever).
+
+### 3. ApplicationStage — wire the queue through
+
+`infra/application_stage.py`:
+
+```python
+opennext_revalidation_queue=messaging.opennext_revalidation_queue,
+```
+
+In the `ComputeStack(...)` call alongside the existing queue params.
+
+### 4. CDK / DeliveryStack / SNS — no changes
+
+This pipeline is fully internal to OpenNext; no CloudFront, SNS, or external integration changes are required.
+
+## Critical files
+
+**Edit:**
+- `infra/stacks/messaging_stack.py` — add `opennext_revalidation_queue` + DLQ + SSM exports
+- `infra/stacks/compute_stack.py` — accept queue param; add env vars + send permission to `FrontendFn`; add `OpenNextRevalidationFn` + SQS event source
+- `infra/application_stage.py` — pass the new queue from MessagingStack to ComputeStack
+- `tests/infra/test_compute_stack.py` and `tests/infra/test_messaging_stack.py` — update fixtures and subscription/queue counts
+
+**Reference (no edits):**
+- `frontend/.open-next/revalidation-function/` — bundle output by `open-next build`; the Lambda code lives here
+- `frontend/.open-next/open-next.output.json` — OpenNext's declaration of the function and its expected wiring
+
+## Verification
+
+**Local synth**:
+
+```sh
+ENVIRONMENT=production poetry run cdk synth --quiet
+grep -l OpenNextRevalidation cdk.out/assembly-SteamPulse-Production/*.template.json
+```
+
+Should match in both Compute and Messaging templates.
+
+**Production smoke test** (requires deploy):
+
+1. After deploy, confirm `REVALIDATION_QUEUE_URL` appears in `aws lambda get-function-configuration --function-name <FrontendFn>` env vars.
+2. Re-run the proof loop from the prior cache-until-changed test:
+   - Bump `games.last_analyzed` for appid 3205380 in the prod DB
+   - Invoke `RevalidateFrontendFn` with a synthetic SQS event
+   - Hit `https://<frontend-fn-url>/games/3205380/...` once → `x-nextjs-cache: STALE` (expected, this enqueues the re-render)
+   - Wait 5–10 seconds
+   - Hit again → `x-nextjs-cache: HIT` and the rendered HTML shows the new `last_analyzed`
+3. Tail `/steampulse/production/opennext-revalidation` — should see one invocation per re-rendered path.
+4. Confirm DLQ depth stays at 0.
+
+**Rollback**: revert the messaging + compute stack edits. The OpenNext server function falls back to `QueueDoesNotExist` errors but the rest of the system keeps working — pages just stay STALE again.
+
+## Cost notes
+
+- SQS: free tier covers ≪1M requests/month; one revalidation per re-analysis × ~200 wedge games × <30 cycles/month = ~6,000 messages — free.
+- Lambda: per render = same cost as a normal SSR request (~1s × 512MB). At wedge volume, well under $1/month.
+- DynamoDB: revalidation reads/writes the existing `OpenNextCacheTable` — already pay-per-request, marginal.
+
+Total expected delta: under $5/month at 10× scale.
+
+## Out of scope
+
+- CloudFront edge invalidation (separate prompt: `scripts/prompts/game-report-cloudfront-invalidation.md`)
+- Migrating the existing `RevalidateFrontendFn` or messaging plumbing
+- Genre / tag / developer / publisher pages (same fix lands automatically once they adopt the data-cache pattern)
+- OpenNext warmer function (separate concern; reduces cold-start latency, not correctness)
+
+## Sources
+
+- [OpenNext AWS revalidation flow](https://opennext.js.org/aws/inner_workings/components/revalidation_function)
+- [OpenNext open-next.output.json schema](https://opennext.js.org/aws/inner_workings/architecture)
+- [Next.js revalidateTag](https://nextjs.org/docs/app/api-reference/functions/revalidateTag)

--- a/tests/infra/conftest.py
+++ b/tests/infra/conftest.py
@@ -1,0 +1,32 @@
+"""Test fixtures for infra synth tests.
+
+The OpenNext bundles under `frontend/.open-next/` are build artifacts (not
+committed). CDK synth requires those directories to exist; in CI without a
+prior `open-next build`, ComputeStack would error before assertions ran.
+The autouse fixture stubs whichever bundle directories are missing so synth
+can proceed.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+_BUNDLES = (
+    "frontend/.open-next/server-functions/default",
+    "frontend/.open-next/revalidation-function",
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_opennext_bundles() -> None:
+    """Create stub OpenNext bundle dirs when missing (CI without frontend build)."""
+    for rel in _BUNDLES:
+        path = pathlib.Path(rel)
+        if path.exists():
+            continue
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "index.mjs").write_text(
+            "export const handler = async () => ({ statusCode: 200 });\n"
+        )

--- a/tests/infra/conftest.py
+++ b/tests/infra/conftest.py
@@ -1,32 +1,32 @@
 """Test fixtures for infra synth tests.
 
 The OpenNext bundles under `frontend/.open-next/` are build artifacts (not
-committed). CDK synth requires those directories to exist; in CI without a
-prior `open-next build`, ComputeStack would error before assertions ran.
-The autouse fixture stubs whichever bundle directories are missing so synth
-can proceed.
+committed). CDK synth reads them via `Code.from_asset`, so without a prior
+`open-next build` ComputeStack would error before assertions ran. The
+autouse fixture redirects the module-level bundle paths to per-test
+temp dirs containing stub `index.mjs` files — keeping the working tree
+untouched so a missing real build still fails loudly during `cdk deploy`.
 """
 
 from __future__ import annotations
 
-import pathlib
+from pathlib import Path
 
 import pytest
 
-_BUNDLES = (
-    "frontend/.open-next/server-functions/default",
-    "frontend/.open-next/revalidation-function",
+_BUNDLE_PATH_VARS = (
+    "stacks.compute_stack._OPEN_NEXT_SERVER",
+    "stacks.compute_stack._OPEN_NEXT_REVALIDATION",
 )
 
 
 @pytest.fixture(autouse=True)
-def _stub_opennext_bundles() -> None:
-    """Create stub OpenNext bundle dirs when missing (CI without frontend build)."""
-    for rel in _BUNDLES:
-        path = pathlib.Path(rel)
-        if path.exists():
-            continue
-        path.mkdir(parents=True, exist_ok=True)
-        (path / "index.mjs").write_text(
+def _stub_opennext_bundles(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point bundle paths at per-test temp dirs with a stub entrypoint."""
+    for i, dotted in enumerate(_BUNDLE_PATH_VARS):
+        bundle = tmp_path / f"opennext-bundle-{i}"
+        bundle.mkdir()
+        (bundle / "index.mjs").write_text(
             "export const handler = async () => ({ statusCode: 200 });\n"
         )
+        monkeypatch.setattr(dotted, str(bundle))

--- a/tests/infra/test_compute_stack.py
+++ b/tests/infra/test_compute_stack.py
@@ -110,3 +110,36 @@ def test_compute_stack_batches_spoke_ingest_sqs_events(template: assertions.Temp
             "FunctionResponseTypes": ["ReportBatchItemFailures"],
         },
     )
+
+
+def test_frontend_fn_wires_opennext_revalidation_queue_env(
+    template: assertions.Template,
+) -> None:
+    """FrontendFn must expose REVALIDATION_QUEUE_URL/REGION so OpenNext can enqueue."""
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Environment": {
+                "Variables": assertions.Match.object_like(
+                    {
+                        "REVALIDATION_QUEUE_URL": assertions.Match.any_value(),
+                        "REVALIDATION_QUEUE_REGION": assertions.Match.any_value(),
+                    }
+                )
+            }
+        },
+    )
+
+
+def test_opennext_revalidation_event_source_wired(
+    template: assertions.Template,
+) -> None:
+    """OpenNextRevalidationFn drains the revalidation queue with the expected batching."""
+    template.has_resource_properties(
+        "AWS::Lambda::EventSourceMapping",
+        {
+            "BatchSize": 5,
+            "MaximumBatchingWindowInSeconds": 2,
+            "FunctionResponseTypes": ["ReportBatchItemFailures"],
+        },
+    )

--- a/tests/infra/test_compute_stack.py
+++ b/tests/infra/test_compute_stack.py
@@ -39,6 +39,7 @@ def template() -> assertions.Template:
     email_queue = sqs.Queue(stack, "EmailQueue")
     cache_invalidation_queue = sqs.Queue(stack, "CacheInvalidationQueue")
     frontend_revalidation_queue = sqs.Queue(stack, "FrontendRevalidationQueue")
+    opennext_revalidation_queue = sqs.Queue(stack, "OpenNextRevalidationQueue")
 
     config = SteamPulseConfig(
         ENVIRONMENT="production",
@@ -72,6 +73,7 @@ def template() -> assertions.Template:
         email_queue=email_queue,
         cache_invalidation_queue=cache_invalidation_queue,
         frontend_revalidation_queue=frontend_revalidation_queue,
+        opennext_revalidation_queue=opennext_revalidation_queue,
         spoke_crawl_queue_urls="https://sqs.us-east-1.amazonaws.com/123456789012/steampulse-spoke-crawl-us-east-1-production",
     )
     return assertions.Template.from_stack(compute)


### PR DESCRIPTION
Carefully check this PR!!  It implements promt at: scripts/prompts/opennext-revalidation-pipeline.md.

Specific things to verify:
- **Closes the cache-until-changed loop**: end-to-end production testing of PR #130 revealed `revalidateTag` was firing but pages stayed STALE forever — `FrontendFn` logs showed `QueueDoesNotExist: The specified queue does not exist.` because OpenNext's internal SQS queue + consumer Lambda were never provisioned. This PR adds them.
- **No placeholder fallback on `OpenNextRevalidationFn`**: code is loaded directly from `frontend/.open-next/revalidation-function/` — synth will fail loudly if `open-next build` hasn't been run before deploy. Existing `FrontendFn` still has the older fallback pattern; deliberately left untouched (separate cleanup).
- **New env vars on `FrontendFn`**: `REVALIDATION_QUEUE_URL` and `REVALIDATION_QUEUE_REGION`. Without these, OpenNext can't enqueue stale-page re-renders. Confirm the env values resolve to the new queue at deploy time.
- **IAM grants**: `FrontendFn` gains `sqs:SendMessage` on the new queue; `OpenNextRevalidationFn` gains read/write on `frontend_bucket` and `OpenNextCacheTable` (same access pattern as `FrontendFn` since both functions read/write the OpenNext data cache).
- **Reserved concurrency = 5**: bounds cost during burst re-render (e.g., a re-analyze cycle invalidating many tags at once). OpenNext SQS tolerates backpressure if exceeded.
- **No SNS subscription**: this queue is fed directly by `FrontendFn` via the AWS SDK at runtime — not a topic subscriber. `tests/infra/test_messaging_stack.py` subscription count assertion stays at 5.
- **CACHE_BUCKET_KEY_PREFIX must match** between `FrontendFn` and `OpenNextRevalidationFn` so they read/write the same per-build namespace. Both use the same `self.node.try_get_context('build-id')` expression at synth time → identical values.
- **Pre-deploy reminder**: rotate `REVALIDATE_TOKEN` (SSM `/steampulse/production/frontend/revalidate-token`) — leaked into a transcript during testing of PR #130.