### PR TITLE
feature/revalidate-page-and-tag: call revalidatePath alongside revalidateTag

### DIFF
--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -1,7 +1,10 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import type { NextRequest } from "next/server";
 
-// 'max' = stale served while a fresh fetch fills the cache in the background.
+// Pair documented by Next.js as "complementary primitives often used together":
+// revalidatePath busts the rendered page HTML; revalidateTag busts the shared
+// fetches. Both are needed for dynamic routes — tag alone leaves the page HTML
+// fresh in OpenNext's S3 cache.
 export async function POST(req: NextRequest) {
   const expectedToken = process.env.REVALIDATE_TOKEN;
   if (!expectedToken) {
@@ -22,10 +25,15 @@ export async function POST(req: NextRequest) {
   }
 
   const appid = (body as { appid?: unknown })?.appid;
+  const slug = (body as { slug?: unknown })?.slug;
   if (typeof appid !== "number" || !Number.isInteger(appid) || appid <= 0) {
     return Response.json({ ok: false, error: "bad_appid" }, { status: 400 });
   }
+  if (typeof slug !== "string" || slug.length === 0) {
+    return Response.json({ ok: false, error: "bad_slug" }, { status: 400 });
+  }
 
+  revalidatePath(`/games/${appid}/${slug}`);
   revalidateTag(`game-${appid}`, "max");
-  return Response.json({ ok: true, appid, now: Date.now() });
+  return Response.json({ ok: true, appid, slug, now: Date.now() });
 }

--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -29,7 +29,16 @@ export async function POST(req: NextRequest) {
   if (typeof appid !== "number" || !Number.isInteger(appid) || appid <= 0) {
     return Response.json({ ok: false, error: "bad_appid" }, { status: 400 });
   }
-  if (typeof slug !== "string" || slug.length === 0) {
+  // Slug format matches lib/format.ts slugify output (^[a-z0-9-]+$, no
+  // leading/trailing hyphens, ≤100 chars). Defense in depth — caller is
+  // already token-authenticated, but constraining the path keeps a
+  // misformed event from probing unintended routes.
+  if (
+    typeof slug !== "string" ||
+    slug.length === 0 ||
+    slug.length > 100 ||
+    !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(slug)
+  ) {
     return Response.json({ ok: false, error: "bad_slug" }, { status: 400 });
   }
 

--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -29,14 +29,13 @@ export async function POST(req: NextRequest) {
   if (typeof appid !== "number" || !Number.isInteger(appid) || appid <= 0) {
     return Response.json({ ok: false, error: "bad_appid" }, { status: 400 });
   }
-  // Slug format matches lib/format.ts slugify output (^[a-z0-9-]+$, no
-  // leading/trailing hyphens, ≤100 chars). Defense in depth — caller is
-  // already token-authenticated, but constraining the path keeps a
-  // misformed event from probing unintended routes.
+  // Slug format matches lib/format.ts slugify output: lowercase alphanumerics
+  // separated by single hyphens, no leading/trailing hyphens. Defense in
+  // depth — caller is already token-authenticated, but constraining the path
+  // keeps a malformed event from probing unintended routes.
   if (
     typeof slug !== "string" ||
     slug.length === 0 ||
-    slug.length > 100 ||
     !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(slug)
   ) {
     return Response.json({ ok: false, error: "bad_slug" }, { status: 400 });

--- a/reports/state_of_roguelike_deckbuilder/state_of_roguelike_deckbuilder.tex
+++ b/reports/state_of_roguelike_deckbuilder/state_of_roguelike_deckbuilder.tex
@@ -1,4 +1,4 @@
-% Created 2026-04-24 Fri 17:45
+% Created 2026-04-25 Sat 14:40
 % Intended LaTeX compiler: pdflatex
 \documentclass[11pt,letterpaper]{report}
 \usepackage[utf8]{inputenc}
@@ -34,7 +34,7 @@
 
 \maketitle
 \part*{At a Glance}
-\label{sec:orge5c08ca}
+\label{sec:org898f627}
 \textbf{At a Glance}
 
 \begin{enumerate}
@@ -47,7 +47,7 @@
 \item \# [TODO: write a 7th headline finding, or trim to 6]
 \end{enumerate}
 \part*{How to read this report}
-\label{sec:orgdbfb269}
+\label{sec:org2bc25c8}
 Roguelike deckbuilder players stop playing when winning stops feeling like discovery — not when they lose.
 
 The genre contract is unusually strict. Slay the Spire set the template: a run fits in a single sitting, card synergies are the primary skill expression, and meta-progression persists between deaths. Balatro extended the contract by proving the scoring ceiling itself can be the endgame. Monster Train demonstrated that a genuinely novel spatial mechanic — three floors of positional defense — earns hundreds of hours on its own. Any game shipping in this niche inherits all three promises on day one: strategic depth, run variety, and a reason to return after every loss.
@@ -56,37 +56,37 @@ The games that pull ahead all do the same thing: they reward discovery over exec
 
 For a developer shipping here: broad viable build diversity and a difficulty curve that rewards reads over rolls are the two investments this audience pays back. Everything else is polish.
 \part*{SECTION 1 — THE MARKET}
-\label{sec:orgfb72332}
+\label{sec:org99372d4}
 
 \chapter*{At a Glance — The Market}
-\label{sec:org319806b}
+\label{sec:orga3ae26f}
 \chapter*{Market size and growth}
-\label{sec:org352006b}
+\label{sec:org9c056b1}
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/releases_per_year.pdf}
-\caption{\label{fig:org1df9503}New releases per year in the Roguelike Deckbuilder genre. Source: SteamPulse, release\_date for 120 games, 2026-04-24.}
+\caption{\label{fig:org7c337d0}New releases per year in the Roguelike Deckbuilder genre. Source: SteamPulse, release\_date for 120 games, 2026-04-24.}
 \end{figure}
 \chapter*{Pricing and discounting}
-\label{sec:orgb22dc98}
+\label{sec:orgda11e57}
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/price_distribution.pdf}
-\caption{\label{fig:orga573aeb}Launch price distribution across Roguelike Deckbuilder games. Source: SteamPulse, current Steam price for 120 games, 2026-04-24.}
+\caption{\label{fig:orga4d05d1}Launch price distribution across Roguelike Deckbuilder games. Source: SteamPulse, current Steam price for 120 games, 2026-04-24.}
 \end{figure}
 \chapter*{Recent wins and recent losses}
-\label{sec:orgcf3e8bb}
+\label{sec:orgddeed6d}
 \chapter*{Implications for The Market}
-\label{sec:org6718cce}
+\label{sec:orgf91575c}
 \part*{SECTION 2 — THE PLAYERS}
-\label{sec:orgc37df4a}
+\label{sec:org131ba25}
 
 \chapter*{At a Glance — The Players}
-\label{sec:orga246e54}
+\label{sec:org6ee6872}
 \chapter*{Who plays this genre}
-\label{sec:org486faf3}
+\label{sec:orga8e2359}
 \chapter*{The churn wall}
-\label{sec:org7421226}
+\label{sec:org29005b4}
 Median player drop-off in this genre occurs at hour \textbf{20}.
 
 The primary reason cited across the dataset:
@@ -99,14 +99,14 @@ Build convergence: players identify the dominant strategy or exhaust the effecti
 — quoted from \emph{Balatro}
 \end{quote}
 \chapter*{Audience overlap}
-\label{sec:org1308496}
+\label{sec:orgfa77cc5}
 \chapter*{Implications for The Players}
-\label{sec:org8343dc3}
+\label{sec:orge20c06f}
 \part*{SECTION 3 — THE FRICTION \& THE OPPORTUNITY}
-\label{sec:orgfadf65a}
+\label{sec:org75b7e10}
 
 \chapter*{At a Glance — Friction \& Opportunity}
-\label{sec:org9bbd69a}
+\label{sec:org3bf1d99}
 \begin{itemize}
 \item \textbf{Friction:} Item/Card Pool Dilution Degrades Build Agency at High Unlock Counts (12 games)
 \item \textbf{Friction:} RNG Dominates Outcomes at Higher Difficulty Tiers, Undermining Skill Expression (18 games)
@@ -114,14 +114,14 @@ Build convergence: players identify the dominant strategy or exhaust the effecti
 \item \textbf{Wishlist:} Item Pool Filter or Ban Mechanic to Exclude Weak or Unwanted Unlocks (12 games)
 \end{itemize}
 \chapter*{Friction clusters}
-\label{sec:org4f3bc9d}
+\label{sec:org41888d6}
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/friction_counts.pdf}
-\caption{\label{fig:org7d2dfc4}Friction clusters in Roguelike Deckbuilder by cross-game mention count. Source: SteamPulse synthesis of 120 games' reviews, 2026-04-24.}
+\caption{\label{fig:orgeb71585}Friction clusters in Roguelike Deckbuilder by cross-game mention count. Source: SteamPulse synthesis of 120 games' reviews, 2026-04-24.}
 \end{figure}
 \section*{Item/Card Pool Dilution Degrades Build Agency at High Unlock Counts}
-\label{sec:orgeec62b1}
+\label{sec:orga82b024}
 As players unlock more cards, jokers, or items, the pool expands to include weak options that crowd out viable synergy pieces. Players report that runs become progressively harder to pilot toward an intended build as the pool grows, paradoxically making progression feel like a punishment.
 
 Mentioned in 12 games in the dataset.
@@ -132,7 +132,7 @@ Mentioned in 12 games in the dataset.
 — quoted from \emph{Balatro}
 \end{quote}
 \section*{RNG Dominates Outcomes at Higher Difficulty Tiers, Undermining Skill Expression}
-\label{sec:org9aca8f1}
+\label{sec:orge706980}
 Across virtually every game in the genre, players who invest 20–100 hours and push to higher ascension or difficulty levels report that run outcomes increasingly feel decided by early card/item offerings rather than player decisions, converting what should be a mastery payoff into a luck check.
 
 Mentioned in 18 games in the dataset.
@@ -143,7 +143,7 @@ Mentioned in 18 games in the dataset.
 — quoted from \emph{Slay the Spire}
 \end{quote}
 \section*{Boss and Elite Encounters Hard-Counter Entire Build Archetypes Without Counterplay}
-\label{sec:org733b781}
+\label{sec:org82d4431}
 In multiple titles, specific boss mechanics — ability-disabling, stat-erasing, or build-invalidating phases — arrive without telegraph and negate hours of deck construction. Players describe these as 'instant brick' moments that feel punitive rather than challenging.
 
 Mentioned in 14 games in the dataset.
@@ -154,7 +154,7 @@ Mentioned in 14 games in the dataset.
 — quoted from \emph{Slay the Spire 2}
 \end{quote}
 \section*{Content Exhaustion After 15–40 Hours: Full Card/Enemy Pool Visible Too Early}
-\label{sec:org27a96b2}
+\label{sec:orgf1c947a}
 Players in mid-tier titles consistently report seeing the complete card pool within two to four runs, at which point the discovery loop — the genre's primary retention driver — collapses. The 'one more run' compulsion requires the possibility of encountering something new.
 
 Mentioned in 15 games in the dataset.
@@ -165,7 +165,7 @@ Mentioned in 15 games in the dataset.
 — quoted from \emph{Luck be a Landlord}
 \end{quote}
 \section*{Absence of Meta-Progression Removes Forward Momentum After Failed Runs}
-\label{sec:org958654c}
+\label{sec:org39c40d6}
 Games without any persistent unlock or reward structure between runs see players disengage after content exhaustion or repeated losses, because there is no incremental signal of progress. The genre standard — set by Hades and Slay the Spire — is that every run, win or lose, advances something.
 
 Mentioned in 16 games in the dataset.
@@ -176,7 +176,7 @@ Mentioned in 16 games in the dataset.
 — quoted from \emph{Luck be a Landlord}
 \end{quote}
 \section*{Slow Animations With No Speed Toggle Create Pacing Friction Across Every Run}
-\label{sec:org2e3ae67}
+\label{sec:orge6fc1d0}
 Unskippable or insufficiently fast card play, boss attack, and result animations are a near-universal complaint across the genre. Players who replay content hundreds of times find default pacing multiplies session time without adding value.
 
 Mentioned in 14 games in the dataset.
@@ -187,7 +187,7 @@ Mentioned in 14 games in the dataset.
 — quoted from \emph{SpellRogue}
 \end{quote}
 \section*{Forced or Unavoidable Card/Item Additions Bloat Decks and Remove Curation Agency}
-\label{sec:org1954f52}
+\label{sec:orgecfb5f4}
 Multiple titles require players to add cards or items after every encounter with no skip, no removal, and no alternative. This directly contradicts the deckbuilder fantasy of intentional construction and is one of the genre's most-cited structural design failures.
 
 Mentioned in 10 games in the dataset.
@@ -198,7 +198,7 @@ Mentioned in 10 games in the dataset.
 — quoted from \emph{Cardboard Town}
 \end{quote}
 \section*{Opaque Mechanics and Missing Tooltips Force Players to Wiki}
-\label{sec:orgf3c1246}
+\label{sec:orge098111}
 Status effects, keyword interactions, and hidden enemy mechanics are consistently underdocumented across the genre. Players describe discovering core rules through deaths rather than UI, creating frustration-dropout in the first 1–3 hours before the strategic layer can hook them.
 
 Mentioned in 11 games in the dataset.
@@ -209,14 +209,14 @@ Mentioned in 11 games in the dataset.
 — quoted from \emph{9 Kings}
 \end{quote}
 \chapter*{Wishlist signals}
-\label{sec:orgd6868c2}
+\label{sec:org1f76885}
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/wishlist_counts.pdf}
-\caption{\label{fig:org1d96920}Wishlist signals in Roguelike Deckbuilder by cross-game mention count. Source: SteamPulse synthesis of 120 games' reviews, 2026-04-24.}
+\caption{\label{fig:orge4b3090}Wishlist signals in Roguelike Deckbuilder by cross-game mention count. Source: SteamPulse synthesis of 120 games' reviews, 2026-04-24.}
 \end{figure}
 \section*{Randomized Daily/Weekly Runs With Global Leaderboards}
-\label{sec:org824391c}
+\label{sec:orgedea8b8}
 Players across high-playtime cohorts consistently request seeded daily runs that provide a shared challenge with competitive scoring. This is positioned as the primary reactivation mechanism for players who have exhausted standard content.
 
 Mentioned in 10 games in the dataset.
@@ -227,7 +227,7 @@ Mentioned in 10 games in the dataset.
 — quoted from \emph{Balatro}
 \end{quote}
 \section*{Item Pool Filter or Ban Mechanic to Exclude Weak or Unwanted Unlocks}
-\label{sec:org0de1527}
+\label{sec:org037d634}
 Players who have unlocked the full game content want control over what appears in their pools, preventing weak or contextually irrelevant items from diluting runs. Vampire Survivors' item locking is frequently cited as the model.
 
 Mentioned in 12 games in the dataset.
@@ -238,7 +238,7 @@ Mentioned in 12 games in the dataset.
 — quoted from \emph{Balatro}
 \end{quote}
 \section*{Meaningful Post-Completion Ascension or Endgame Challenge Layer}
-\label{sec:org4c9e161}
+\label{sec:orge890ba4}
 The genre's most engaged players universally want structured post-completion difficulty — a Slay the Spire-style ascension ladder, heat system, or endless modifier stack — that gives a reason to keep running after all content is cleared.
 
 Mentioned in 14 games in the dataset.
@@ -249,7 +249,7 @@ Mentioned in 14 games in the dataset.
 — quoted from \emph{StarVaders}
 \end{quote}
 \section*{Co-op Multiplayer (Synchronous or Asynchronous) for the Core Roguelike Loop}
-\label{sec:org3c8e8dc}
+\label{sec:org38e1b39}
 Players across the genre repeatedly request co-op modes — either full synchronous runs or asynchronous PvP/score challenge. The Slay the Spire 2 co-op implementation is the current reference point generating the strongest positive signal.
 
 Mentioned in 10 games in the dataset.
@@ -260,7 +260,7 @@ Mentioned in 10 games in the dataset.
 — quoted from \emph{Slay the Spire 2}
 \end{quote}
 \section*{Damage/Outcome Preview Before Committing a Play}
-\label{sec:orge0e140d}
+\label{sec:org410814a}
 Players in multiple titles request a real-time or pre-commit preview showing how much incoming damage will resolve or what the outcome of a card play will be. Monster Train's damage preview overlay is the most-cited benchmark.
 
 Mentioned in 9 games in the dataset.
@@ -271,7 +271,7 @@ Mentioned in 9 games in the dataset.
 — quoted from \emph{Wildfrost}
 \end{quote}
 \section*{Expanded Boss and Enemy Roster to Reduce Encounter Repetition}
-\label{sec:org18f3dd9}
+\label{sec:org523b3f0}
 Across games with 3–5 bosses and a shallow enemy pool, players with 30+ hours explicitly request additional boss types and elite encounters as the primary content investment that would extend their engagement.
 
 Mentioned in 13 games in the dataset.
@@ -282,14 +282,14 @@ Mentioned in 13 games in the dataset.
 — quoted from \emph{Slay the Spire}
 \end{quote}
 \chapter*{The promise gap}
-\label{sec:orgcb4738f}
+\label{sec:org9df52e1}
 \chapter*{Implications for Friction \& Opportunity}
-\label{sec:orgc6f1ced}
+\label{sec:org1fca142}
 \part*{SECTION 4 — THE PLAYBOOK}
-\label{sec:orged80e9d}
+\label{sec:org736c47f}
 
 \chapter*{At a Glance — The Playbook}
-\label{sec:org4b0352c}
+\label{sec:orgf047c6b}
 \begin{itemize}
 \item Ship an item/card pool filter or ban mechanic so players can exclude weak or irrelevant unlocks from appearing in runs
 \item Add an animation speed toggle (minimum 2x, ideally 4x or instant-resolve) as a first-session accessible setting
@@ -297,56 +297,56 @@ Mentioned in 13 games in the dataset.
 \item Design a meaningful meta-progression layer with at minimum a lightweight unlock ladder that rewards every run, win or lose
 \end{itemize}
 \chapter*{Ranked priorities for builders}
-\label{sec:orgdebc19f}
+\label{sec:orgf36ea92}
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/dev_priorities.pdf}
-\caption{\label{fig:org4ae4025}Ranked dev priorities for Roguelike Deckbuilder — implementation effort vs cross-game demand. Source: SteamPulse synthesis of 120 games' dev\_priorities, 2026-04-24.}
+\caption{\label{fig:orgaac7704}Ranked dev priorities for Roguelike Deckbuilder — implementation effort vs cross-game demand. Source: SteamPulse synthesis of 120 games' dev\_priorities, 2026-04-24.}
 \end{figure}
 \section*{1. Ship an item/card pool filter or ban mechanic so players can exclude weak or irrelevant unlocks from appearing in runs}
-\label{sec:org18289a6}
+\label{sec:org911436a}
 \textbf{Effort:} medium | \textbf{Mentioned by:} 12 games
 
 Pool dilution is the single most consistent cross-game friction — it paradoxically makes progression feel like punishment, converting the genre's core retention loop (unlock → more options) into a negative. Every game with a large unlock pool faces this problem, and the fix is table-stakes for long-term replayability.
 \section*{2. Add an animation speed toggle (minimum 2x, ideally 4x or instant-resolve) as a first-session accessible setting}
-\label{sec:org266718f}
+\label{sec:org3f56490}
 \textbf{Effort:} low | \textbf{Mentioned by:} 14 games
 
 Slow animations are cited in nearly every game in the corpus, always as friction and never as a positive. The cost of this fix is minimal; the retention impact for high-playtime players running their 50th+ session is significant.
 \section*{3. Implement a global or account-level difficulty progression so players exploring new characters or decks do not restart from difficulty 1}
-\label{sec:orge00960e}
+\label{sec:org32b1fd2}
 \textbf{Effort:} medium | \textbf{Mentioned by:} 8 games
 
 Per-character ascension resets are the leading structural reason players abandon character variety — the genre's primary replayability axis. The Slay the Spire model (shared ascension unlocked incrementally) is the established solution.
 \section*{4. Design a meaningful meta-progression layer with at minimum a lightweight unlock ladder that rewards every run, win or lose}
-\label{sec:orgba26437}
+\label{sec:org5b0574f}
 \textbf{Effort:} high | \textbf{Mentioned by:} 16 games
 
 The absence of inter-run progression is the primary churn driver in games without it, and the standard has been set by genre leaders. Players who have no incremental signal of progress after a loss have no structural reason to start the next run.
 \section*{5. Audit and redesign boss/elite encounters that hard-counter build archetypes without counterplay — replace flat invalidation with readable pressure mechanics}
-\label{sec:org4e48270}
+\label{sec:org305883e}
 \textbf{Effort:} high | \textbf{Mentioned by:} 14 games
 
 Build-invalidating boss encounters appear in the friction data of nearly every game surveyed and are the top driver of run-abandonment at peak investment (30–90 minutes into a run). These are the moments that convert fans into negative reviewers.
 \section*{6. Add a daily or weekly seeded run mode with a global leaderboard}
-\label{sec:orgea4b4d2}
+\label{sec:org79cb8e4}
 \textbf{Effort:} medium | \textbf{Mentioned by:} 10 games
 
 This is the single most-requested feature across high-playtime player cohorts in multiple games (Balatro, Slay the Spire, Monster Train 2, SpellRogue). It reactivates dormant players who have cleared base content and provides recurring organic community touchpoints.
 \section*{7. Rebalance the card/item pool so that at least 60–70\% of available options are viable in at least one endgame build archetype}
-\label{sec:org5b64caa}
+\label{sec:orgc192f04}
 \textbf{Effort:} high | \textbf{Mentioned by:} 15 games
 
 Build homogenization — runs converging to 2–5 dominant strategies — is the primary long-term replayability killer across the corpus. Players explicitly name card count and variety as purchase justifications; when the effective pool is a fraction of the total, trust in the game's systems erodes.
 \section*{8. Implement a pre-commit outcome or damage preview for key card or ability plays}
-\label{sec:orge828978}
+\label{sec:orgb7ab7e3}
 \textbf{Effort:} medium | \textbf{Mentioned by:} 9 games
 
 Opaque death states — 'I don't know what killed me' — are a top early-session churn trigger. Monster Train's damage preview is the cited benchmark. This converts frustration-dropout into learning-retention.
 \chapter*{Opportunity map}
-\label{sec:org4260e37}
+\label{sec:org39a66f3}
 \chapter*{What to avoid}
-\label{sec:org479083d}
+\label{sec:orgd881982}
 The most common mistakes builders make in this genre — each is the inverse of a friction cluster from Section 3:
 
 \begin{enumerate}
@@ -357,31 +357,31 @@ The most common mistakes builders make in this genre — each is the inverse of 
 \item \textbf{Don't ship absence of meta-progression removes forward momentum after failed runs} — see Section 3 for the full pattern. \# [TODO: add a specific game that fell into this trap, with one quote.]
 \end{enumerate}
 \chapter*{Implications for The Playbook}
-\label{sec:orgefd4793}
+\label{sec:org09057f9}
 \part*{APPENDIX A — Benchmark game profiles}
-\label{sec:org51b3f50}
+\label{sec:org404145d}
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/top_games_by_reviews.pdf}
-\caption{\label{fig:orgfb6edaa}Top 10 games in Roguelike Deckbuilder by total Steam review count. Source: SteamPulse, Steam review\_count data, 2026-04-24.}
+\caption{\label{fig:org6671fd5}Top 10 games in Roguelike Deckbuilder by total Steam review count. Source: SteamPulse, Steam review\_count data, 2026-04-24.}
 \end{figure}
 \chapter*{Slay the Spire (appid 646570)}
-\label{sec:orgb50c7ba}
+\label{sec:org9f0ddf6}
 The single most-cited reference across the entire input set — present in competitive\_context for nearly every game analyzed. Establishes the genre baseline for card pool depth, ascension difficulty, run pacing, and the standard against which all other deckbuilders are measured.
 \chapter*{Balatro (appid 2379780)}
-\label{sec:orgd773597}
+\label{sec:orgb3a68a0}
 The second most frequently referenced game across the input corpus, cited as a peer or aspirational comparison in dozens of reports. Represents the current ceiling for accessible deckbuilder design: high player agency, exceptional dopamine loop, and the 'scoring ceiling as endgame' innovation.
 \chapter*{Monster Train (appid 1102190)}
-\label{sec:org16a56eb}
+\label{sec:org4bcd1de}
 Appears in competitive\_context for the majority of input reports, consistently cited as the top-tier alternative to Slay the Spire. Establishes the standard for spatial mechanical differentiation, dual-faction combinatorics, and run pacing in the 30–60 minute sweet spot.
 \chapter*{Slay the Spire 2 (appid 2868840)}
-\label{sec:org3e0c3ac}
+\label{sec:orgb9a7399}
 Heavily referenced in reports from late 2025 and 2026, cited as the current active benchmark for co-op deckbuilding and as a direct replacement signal for multiple games in the corpus. Its April patch controversy is the most widely discussed live-balance event in the dataset.
 \chapter*{Hades (appid 1016730)}
-\label{sec:org2c9bfd5}
+\label{sec:org39b91d7}
 Consistently invoked across the input corpus — not as a direct deckbuilder but as the benchmark for meta-progression design, narrative-in-roguelike integration, and the 'every run advances something' design principle that players cite when criticizing absent persistence systems.
 \part*{APPENDIX B — Methodology}
-\label{sec:orgfc9f896}
+\label{sec:org13c8897}
 This report synthesizes player-stated signal from \textbf{120 games} tagged "Roguelike Deckbuilder" on Steam, analyzed via the SteamPulse 3-phase LLM pipeline (prompt\_version=v1). Synthesis computed: 2026-04-24.
 
 \textbf{Coverage:}
@@ -394,10 +394,10 @@ This report synthesizes player-stated signal from \textbf{120 games} tagged "Rog
 \begin{figure}[H]
 \centering
 \includegraphics[width=0.9\textwidth]{./charts/positive_pct_distribution.pdf}
-\caption{\label{fig:org16f0c60}Distribution of Steam positive-review percentages across the 120 games analyzed. Source: SteamPulse, Steam review\_score data, 2026-04-24.}
+\caption{\label{fig:org72cf06d}Distribution of Steam positive-review percentages across the 120 games analyzed. Source: SteamPulse, Steam review\_score data, 2026-04-24.}
 \end{figure}
 \part*{APPENDIX C — Games included in this analysis}
-\label{sec:org408b213}
+\label{sec:orgf8dfe95}
 \begin{center}
 \begin{tabular}{rlrl}
 Appid & Name & Reviews & Positive \%\\
@@ -525,16 +525,16 @@ Appid & Name & Reviews & Positive \%\\
 \end{tabular}
 \end{center}
 \part*{APPENDIX D — Glossary}
-\label{sec:org8cdb97b}
+\label{sec:org955251a}
 \part*{About SteamPulse}
-\label{sec:org83aad43}
+\label{sec:org79b4cef}
 
 \chapter*{What this report is}
-\label{sec:org3f8ad38}
+\label{sec:org56a504f}
 \chapter*{Commission custom research}
-\label{sec:orgf6d2417}
+\label{sec:org6e0bf28}
 \chapter*{Other reports in this series}
-\label{sec:org4055c46}
+\label{sec:orgcffc9ea}
 \chapter*{Newsletter}
-\label{sec:org5498e44}
+\label{sec:org94e4204}
 \end{document}

--- a/scripts/prompts/game-report-cloudfront-invalidation.md
+++ b/scripts/prompts/game-report-cloudfront-invalidation.md
@@ -1,12 +1,30 @@
 # CloudFront Edge Invalidation for Game Report Pages
 
+## Depends on
+
+This prompt assumes the origin-side cache loop fully works. That requires the
+following PRs to be in place first (in any order, all pre-requisites):
+
+- `feature/game-report-cache-invalidation` — wires `revalidateTag` webhook + queue
+- `feature/opennext-revalidation-pipeline` — provisions OpenNext's internal
+  re-render queue + Lambda
+- `feature/pin-next-build-id` — pins Next BUILD_ID to git SHA so tag namespaces
+  align across deploys
+- `feature/revalidate-page-and-tag` — adds `revalidatePath` alongside
+  `revalidateTag` so the page HTML actually busts (not just the underlying
+  fetches)
+
+Without those four, this CloudFront work would mask deeper origin-cache bugs
+behind aggressive edge invalidations.
+
 ## Context
 
-`feature/game-report-cache-invalidation` (PR #130) closed the Next.js
-data-cache half of "cache-until-changed" for `/games/[appid]/[slug]`:
-re-analysis fires `ReportReadyEvent` → SQS → `RevalidateFrontendFn` →
-POST `/api/revalidate` → `revalidateTag('game-${appid}', 'max')`. The
-OpenNext data cache (S3 + DynamoDB) is now correctly busted.
+After the four PRs above land, the cache-until-changed loop is correct at
+the **origin** (Lambda + OpenNext data cache): re-analysis → `ReportReadyEvent`
+→ SQS → `RevalidateFrontendFn` → POST `/api/revalidate` →
+`revalidatePath` + `revalidateTag('game-${appid}', 'max')` → page HTML and
+underlying fetches both invalidate → next origin hit serves fresh content via
+`OpenNextRevalidationFn`.
 
 **The remaining gap**: CloudFront edge HTML cache is *not* invalidated.
 With `revalidate = 31536000` on the page, OpenNext emits

--- a/scripts/prompts/revalidate-page-and-tag.md
+++ b/scripts/prompts/revalidate-page-and-tag.md
@@ -17,7 +17,7 @@ So when `revalidateTag` runs, OpenNext finds nothing in the tag table linking th
 
 The official Next.js 16 [`revalidatePath` docs](https://nextjs.org/docs/app/api-reference/functions/revalidatePath#building-revalidation-utilities) document the canonical pattern explicitly:
 
-> **`revalidatePath` and `updateTag` are complementary primitives that are often used together** in utility functions to ensure comprehensive data consistency across your application.
+> **`revalidatePath` and `revalidateTag` are complementary primitives that are often used together** in utility functions to ensure comprehensive data consistency across your application.
 
 We implemented half the pattern. This prompt adds the other half.
 
@@ -27,7 +27,7 @@ We implemented half the pattern. This prompt adds the other half.
 
 ## Best-practice foundation
 
-- **Specific path beats pattern form for our use case**. `revalidatePath('/games/[appid]/[slug]', 'page')` would over-invalidate (every report-ready busts every cached game page). `revalidatePath('/games/${appid}/${slug}')` busts exactly one. We have the slug in `ReportReadyEvent.game_name` and `games.slug` in the DB — trivial to thread through.
+- **Specific path beats pattern form for our use case**. `revalidatePath('/games/[appid]/[slug]', 'page')` would over-invalidate (every report-ready busts every cached game page). `revalidatePath('/games/${appid}/${slug}')` busts exactly one. We thread `games.slug` into `ReportReadyEvent.slug` so the exact path is trivial to construct.
 - **No `type` parameter needed for literal paths**. Per docs: "Use a literal path when you want to refresh a single page" — no `type` arg.
 - **Order doesn't matter**. Both calls are sync state mutations on the cache layer; they compose.
 - **Idempotent**. Re-firing the same revalidation is harmless — no double-invalidation cost.

--- a/scripts/prompts/revalidate-page-and-tag.md
+++ b/scripts/prompts/revalidate-page-and-tag.md
@@ -1,0 +1,171 @@
+# Revalidate Page HTML Alongside Tag (Close the Cache-Invalidation Loop)
+
+## Context
+
+After three rounds of cache-until-changed work
+(`feature/game-report-cache-invalidation` → `feature/opennext-revalidation-pipeline` → `feature/pin-next-build-id`), production tests showed the loop still doesn't bust the rendered page HTML. Diagnosis: we only call `revalidateTag('game-${appid}', 'max')`. That marks the underlying `fetch()` cache entries stale, but **does not invalidate the page's HTML cache** for dynamic routes (`/games/[appid]/[slug]`) when `generateStaticParams` returns `[]`.
+
+OpenNext pre-populates DynamoDB tag→path mappings only for routes whose paths are known at build time (the `dynamodb-cache.json` artifact). Dynamic routes are absent — confirmed locally:
+
+```
+$ jq -r '.[] | select(.path.S | contains("games/")) | .path.S' \
+    frontend/.open-next/dynamodb-provider/dynamodb-cache.json
+(empty — zero games/* entries)
+```
+
+So when `revalidateTag` runs, OpenNext finds nothing in the tag table linking the page path to the tag, and the page entry in S3 stays fresh.
+
+The official Next.js 16 [`revalidatePath` docs](https://nextjs.org/docs/app/api-reference/functions/revalidatePath#building-revalidation-utilities) document the canonical pattern explicitly:
+
+> **`revalidatePath` and `updateTag` are complementary primitives that are often used together** in utility functions to ensure comprehensive data consistency across your application.
+
+We implemented half the pattern. This prompt adds the other half.
+
+**Goal**: when a `report-ready` event fires, both the rendered page HTML *and* the underlying tagged fetches invalidate. After this lands, viewers see fresh content on the next visit; OpenNextRevalidationFn fires; the loop is closed.
+
+**Non-goal**: changing the `'max'` semantics on `revalidateTag` (still want SWR for the shared-tag fetches). CloudFront edge invalidation (separate prompt: `game-report-cloudfront-invalidation.md`).
+
+## Best-practice foundation
+
+- **Specific path beats pattern form for our use case**. `revalidatePath('/games/[appid]/[slug]', 'page')` would over-invalidate (every report-ready busts every cached game page). `revalidatePath('/games/${appid}/${slug}')` busts exactly one. We have the slug in `ReportReadyEvent.game_name` and `games.slug` in the DB — trivial to thread through.
+- **No `type` parameter needed for literal paths**. Per docs: "Use a literal path when you want to refresh a single page" — no `type` arg.
+- **Order doesn't matter**. Both calls are sync state mutations on the cache layer; they compose.
+- **Idempotent**. Re-firing the same revalidation is harmless — no double-invalidation cost.
+
+## Design
+
+### 1. Event payload — include `slug`
+
+`src/library-layer/library_layer/events.py`:
+
+```python
+class ReportReadyEvent(BaseEvent):
+    event_type: Literal["report-ready"] = "report-ready"
+    appid: int
+    game_name: str
+    slug: str  # NEW — used by the frontend revalidator to call revalidatePath
+    review_score_desc: str | None = None
+```
+
+`src/lambda-functions/lambda_functions/analysis/handler.py` (around line 152): include the game's slug in the publish call. The slug is already in the `games` row that the handler queried earlier (`game.slug`). Pull it from there:
+
+```python
+publish_event(
+    _sns_client,
+    _content_events_topic_arn,
+    ReportReadyEvent(
+        appid=req.appid,
+        game_name=name,
+        slug=game.slug,
+        review_score_desc=game.review_score_desc,
+    ),
+)
+```
+
+### 2. Revalidate Lambda — pass slug through
+
+`src/lambda-functions/lambda_functions/revalidate_frontend/handler.py`:
+
+- `_extract_appid_and_slug(record)` returns `(appid, slug)` instead of just appid.
+- `_post_revalidate(appid, slug)` POSTs `{"appid": appid, "slug": slug}`.
+- All log lines / metrics keep the existing shape.
+
+### 3. Route handler — call both `revalidatePath` and `revalidateTag`
+
+`frontend/app/api/revalidate/route.ts`:
+
+```ts
+import { revalidatePath, revalidateTag } from "next/cache";
+import type { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const expectedToken = process.env.REVALIDATE_TOKEN;
+  if (!expectedToken) { /* ... unchanged ... */ }
+  if (req.headers.get("x-revalidate-token") !== expectedToken) { /* ... unchanged ... */ }
+
+  let body: unknown;
+  try { body = await req.json(); }
+  catch { return Response.json({ ok: false, error: "bad_json" }, { status: 400 }); }
+
+  const appid = (body as { appid?: unknown })?.appid;
+  const slug = (body as { slug?: unknown })?.slug;
+  if (typeof appid !== "number" || !Number.isInteger(appid) || appid <= 0) {
+    return Response.json({ ok: false, error: "bad_appid" }, { status: 400 });
+  }
+  if (typeof slug !== "string" || slug.length === 0) {
+    return Response.json({ ok: false, error: "bad_slug" }, { status: 400 });
+  }
+
+  // Bust the page HTML cache (OpenNext S3 entry) — the missing piece.
+  revalidatePath(`/games/${appid}/${slug}`);
+  // Bust the shared fetches under one tag — already wired pre-fix.
+  revalidateTag(`game-${appid}`, "max");
+
+  return Response.json({ ok: true, appid, slug, now: Date.now() });
+}
+```
+
+### 4. Tests
+
+- `tests/handlers/test_revalidate_frontend_handler.py` — extend the SNS-wrapped event factories to include `slug`; assert the POST body now contains both `appid` and `slug`. Add a "missing slug → batch failure" case.
+- No new infra tests needed (no infra changes).
+
+### 5. CDK / messaging — no changes
+
+Event shape is additive; the SNS topic, SQS queue, and Lambda configuration all stay as-is. The Pydantic model handles deserialization of older messages with no slug? **No** — `slug` is required (no default). Once the new analysis handler ships, all new events have it. **In-flight events at deploy time** without `slug` will fail validation in `RevalidateFrontendFn` and land on the DLQ — acceptable, since the queue is empty under normal load.
+
+If you want to be defensive about in-flight events, make `slug: str | None = None` on the model and have the route handler 400 on missing slug (already in the design). The Lambda would log + DLQ those records, which we'd manually drain. Keep `slug: str` (required) for the cleaner model — defer the resilience question.
+
+## Critical files
+
+**Edit:**
+- `src/library-layer/library_layer/events.py` — add `slug: str` to `ReportReadyEvent`
+- `src/lambda-functions/lambda_functions/analysis/handler.py` — include `slug=game.slug` in `ReportReadyEvent(...)`
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py` — extract + forward slug
+- `frontend/app/api/revalidate/route.ts` — call `revalidatePath` alongside `revalidateTag`; validate slug
+- `tests/handlers/test_revalidate_frontend_handler.py` — update event factories + add slug-missing case
+
+**Reference (no edits):**
+- `frontend/.open-next/dynamodb-provider/dynamodb-cache.json` — confirms zero pre-populated entries for `/games/[appid]/[slug]` (the bug's root)
+- `scripts/prompts/opennext-revalidation-pipeline.md` — prior PR that wired the OpenNext re-render queue (now actually exercised after this fix)
+
+## Verification
+
+**Local**:
+```sh
+poetry run pytest tests/handlers/test_revalidate_frontend_handler.py
+poetry run pytest tests/infra/  # should still be green
+cd frontend && node_modules/.bin/tsc --noEmit
+node_modules/.bin/next build && node_modules/.bin/open-next build
+```
+
+**Production** (after deploy):
+1. Hit `/games/3205380/omelet-you-cook-3205380` via the Function URL → MISS, then HIT.
+2. Synthetic invoke `RevalidateFrontendFn` with an SNS-wrapped event including `slug: "omelet-you-cook-3205380"`.
+3. Inspect DynamoDB cache table — `96bd8e8/game-3205380` tag entries should have `revalidatedAt = NOW`.
+4. **Hit page again → expect `x-nextjs-cache: STALE`** (this is the new behavior — page entry is now bust). The hit also enqueues a re-render to `OpenNextRevalidationQueue`.
+5. Tail `/steampulse/production/opennext-revalidation` → should see one invocation re-rendering the page.
+6. Hit page a third time → `x-nextjs-cache: HIT` with the just-rendered fresh content.
+7. Bonus end-to-end: trigger a real re-analysis via Step Functions for a known appid; confirm steps 4–6 happen automatically without manual intervention.
+
+**Rollback**: revert the route handler to call only `revalidateTag`. The `slug` field on the event is harmless (extra field; consumers ignore it).
+
+## Why this is the correct end state
+
+- Follows the documented Next.js 16 pattern verbatim ("revalidatePath and revalidateTag are complementary primitives often used together").
+- Precise — invalidates exactly one page per `report-ready`, not the whole catalog.
+- Bisects the responsibility cleanly: `revalidatePath` busts the HTML; `revalidateTag` (with `'max'`) busts the underlying fetches with SWR semantics.
+- Closes every gap we identified through testing: BUILD_ID alignment, OpenNext revalidation queue, page HTML invalidation. After this, the cache-until-changed promise is real.
+
+## Out of scope
+
+- CloudFront edge invalidation (separate prompt).
+- Genre / tag / dev / pub pages (will follow the same `revalidatePath + revalidateTag` pattern when their data-cache work lands).
+- DLQ-resilient handling of in-flight events without `slug` (defer; queue is normally empty).
+
+## Sources
+
+- [Next.js revalidatePath — Building revalidation utilities (v16)](https://nextjs.org/docs/app/api-reference/functions/revalidatePath#building-revalidation-utilities)
+- [Next.js revalidateTag](https://nextjs.org/docs/app/api-reference/functions/revalidateTag)
+- [OpenNext Tag Cache override](https://opennext.js.org/aws/config/overrides/tag_cache)
+- [OpenNext caching internals](https://opennext.js.org/aws/inner_workings/caching)

--- a/src/lambda-functions/lambda_functions/analysis/handler.py
+++ b/src/lambda-functions/lambda_functions/analysis/handler.py
@@ -155,6 +155,7 @@ def handler(event: dict, context: LambdaContext) -> dict:
             ReportReadyEvent(
                 appid=req.appid,
                 game_name=name,
+                slug=game.slug,
                 review_score_desc=game.review_score_desc,
             ),
         )

--- a/src/lambda-functions/lambda_functions/batch_analysis/collect_phase.py
+++ b/src/lambda-functions/lambda_functions/batch_analysis/collect_phase.py
@@ -572,6 +572,7 @@ def _collect_synthesis(
             ReportReadyEvent(
                 appid=appid,
                 game_name=game.name,
+                slug=game.slug,
                 review_score_desc=game.review_score_desc,
             ),
         )

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -34,25 +34,28 @@ def _get_http_client() -> httpx.Client:
     return _http_client
 
 
-def _extract_appid(record: dict) -> int:
-    """Parse the SNS-wrapped ReportReadyEvent body and return the appid."""
+def _extract_event(record: dict) -> tuple[int, str]:
+    """Parse the SNS-wrapped ReportReadyEvent body; return (appid, slug)."""
     body = json.loads(record["body"])
     inner_raw = body.get("Message", body)
     inner = json.loads(inner_raw) if isinstance(inner_raw, str) else inner_raw
     appid = inner.get("appid")
+    slug = inner.get("slug")
     if not isinstance(appid, int):
         raise ValueError(f"missing/invalid appid in event: {inner!r}")
-    return appid
+    if not isinstance(slug, str) or not slug:
+        raise ValueError(f"missing/invalid slug in event: {inner!r}")
+    return appid, slug
 
 
-def _post_revalidate(appid: int) -> None:
+def _post_revalidate(appid: int, slug: str) -> None:
     response = _get_http_client().post(
         f"{_FRONTEND_BASE_URL}/api/revalidate",
         headers={
             "x-revalidate-token": _REVALIDATE_TOKEN,
             "content-type": "application/json",
         },
-        json={"appid": appid},
+        json={"appid": appid, "slug": slug},
     )
     response.raise_for_status()
 
@@ -65,10 +68,10 @@ def handler(event: dict, _context: LambdaContext) -> dict:
     for record in event.get("Records", []):
         message_id = record.get("messageId", "")
         try:
-            appid = _extract_appid(record)
-            _post_revalidate(appid)
+            appid, slug = _extract_event(record)
+            _post_revalidate(appid, slug)
             metrics.add_metric(name="RevalidationsSucceeded", unit=MetricUnit.Count, value=1)
-            logger.info("Revalidated", extra={"appid": appid})
+            logger.info("Revalidated", extra={"appid": appid, "slug": slug})
         except Exception:
             logger.exception("Failed to revalidate", extra={"message_id": message_id})
             metrics.add_metric(name="RevalidationsFailed", unit=MetricUnit.Count, value=1)

--- a/src/library-layer/library_layer/events.py
+++ b/src/library-layer/library_layer/events.py
@@ -107,6 +107,7 @@ class ReportReadyEvent(BaseEvent):
     event_type: Literal["report-ready"] = "report-ready"
     appid: int
     game_name: str
+    slug: str
     review_score_desc: str | None = None
 
 

--- a/tests/handlers/test_collect_phase.py
+++ b/tests/handlers/test_collect_phase.py
@@ -161,6 +161,7 @@ def _stub_backend(cp: Any) -> MagicMock:
 def _install_fake_game(cp: Any) -> Any:
     game = MagicMock()
     game.name = "TF2"
+    game.slug = "tf2-440"
     game.positive_pct = 85
     game.review_count = 500
     game.review_score_desc = "Very Positive"

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -51,9 +51,18 @@ def _get_module() -> Any:
     return h
 
 
+def _slug(appid: int) -> str:
+    return f"test-game-{appid}"
+
+
 def _sns_wrapped_event(appid: int, message_id: str = "msg-1") -> dict:
     """Build an SQS record whose body is the SNS notification envelope."""
-    inner = {"event_type": "report-ready", "appid": appid, "game_name": "Test"}
+    inner = {
+        "event_type": "report-ready",
+        "appid": appid,
+        "game_name": "Test",
+        "slug": _slug(appid),
+    }
     body = {
         "Type": "Notification",
         "TopicArn": "arn:aws:sns:us-east-1:123:content-events",
@@ -80,7 +89,11 @@ def _multi_record_event(records: list[tuple[int, str]]) -> dict:
                     {
                         "Type": "Notification",
                         "Message": json.dumps(
-                            {"event_type": "report-ready", "appid": appid}
+                            {
+                                "event_type": "report-ready",
+                                "appid": appid,
+                                "slug": _slug(appid),
+                            }
                         ),
                     }
                 ),
@@ -92,11 +105,11 @@ def _multi_record_event(records: list[tuple[int, str]]) -> dict:
 
 
 @mock_aws
-def test_happy_path_posts_revalidate_with_token_and_appid(httpx_mock: HTTPXMock) -> None:
+def test_happy_path_posts_revalidate_with_token_appid_slug(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         method="POST",
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
-        json={"ok": True, "appid": 12345, "now": 0},
+        json={"ok": True, "appid": 12345, "slug": _slug(12345), "now": 0},
     )
     handler = _get_module()
     result = handler.handler(_sns_wrapped_event(12345), MockLambdaContext())
@@ -106,7 +119,7 @@ def test_happy_path_posts_revalidate_with_token_and_appid(httpx_mock: HTTPXMock)
     assert len(requests) == 1
     req = requests[0]
     assert req.headers["x-revalidate-token"] == _TOKEN
-    assert json.loads(req.content) == {"appid": 12345}
+    assert json.loads(req.content) == {"appid": 12345, "slug": _slug(12345)}
 
 
 @mock_aws
@@ -148,6 +161,31 @@ def test_missing_appid_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None
 
 
 @mock_aws
+def test_missing_slug_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
+    handler = _get_module()
+    bad_event = {
+        "Records": [
+            {
+                "messageId": "bad-slug",
+                "body": json.dumps(
+                    {
+                        "Type": "Notification",
+                        "Message": json.dumps(
+                            {"event_type": "report-ready", "appid": 5}
+                        ),
+                    }
+                ),
+                "receiptHandle": "r",
+            }
+        ],
+    }
+    result = handler.handler(bad_event, MockLambdaContext())
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "bad-slug"}]}
+    assert httpx_mock.get_requests() == []
+
+
+@mock_aws
 def test_partial_batch_failure_only_reports_failed_record(
     httpx_mock: HTTPXMock,
 ) -> None:
@@ -177,14 +215,16 @@ def test_unwrapped_sqs_body_also_parses(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         method="POST",
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
-        json={"ok": True, "appid": 7, "now": 0},
+        json={"ok": True, "appid": 7, "slug": _slug(7), "now": 0},
     )
     handler = _get_module()
     direct_event = {
         "Records": [
             {
                 "messageId": "direct-1",
-                "body": json.dumps({"event_type": "report-ready", "appid": 7}),
+                "body": json.dumps(
+                    {"event_type": "report-ready", "appid": 7, "slug": _slug(7)}
+                ),
                 "receiptHandle": "r",
             }
         ],


### PR DESCRIPTION
Carefully check this PR!!  It implements promt at: scripts/prompts/revalidate-page-and-tag.md.

Specific things to verify:
- **Closes the cache-until-changed loop**: end-to-end production testing of the prior PRs (#130, #131, the BUILD_ID pin) revealed that `revalidateTag` alone never busted the rendered page HTML for dynamic routes (`/games/[appid]/[slug]` with empty `generateStaticParams`) — only the underlying fetches got invalidated. Per official Next.js 16 docs, `revalidatePath` and `revalidateTag` are "complementary primitives often used together". This PR adds the missing `revalidatePath` half.
- **`ReportReadyEvent.slug` is now required** (no default). In-flight `report-ready` SQS messages published before this deploys will fail validation in `RevalidateFrontendFn` and land on the DLQ. The queue is normally empty under steady-state load, but if you deploy during a re-analysis burst, drain the DLQ manually after.
- **`game.slug` lookup in analysis handler** — `Game.slug` is `str` (required, not nullable) per `library_layer.models.game`, so this can't break unless an upstream creates a Game with an empty slug, which the model would already reject.
- **Route handler validates slug**: 400 on missing/empty/non-string slug. Token check happens first; token-rotation is unaffected.
- **POST body shape changed**: now `{appid: int, slug: str}` instead of `{appid: int}`. The route still 400s the old shape (no slug) so any external caller relying on it would break — there are none beyond `RevalidateFrontendFn`.
- **`revalidatePath` uses literal path** (no `type` param) so only the single appid/slug page is invalidated, not all `/games/*` pages. Cheaper + more precise.
- **No infra changes** — SNS topic, SQS queue, Lambda config all unchanged. Pure code.
- **Pre-deploy reminder**: `REVALIDATE_TOKEN` should already be rotated from the earlier transcript-leak incident. If not, rotate before deploy.