### PR TITLE
feature/s3-page-cache-bust: delete S3 page cache to actually bust dynamic-route HTML

### DIFF
--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -984,6 +984,14 @@ class ComputeStack(cdk.Stack):
                 ],
             )
         )
+        # Direct delete of the OpenNext page-cache file — the only reliable
+        # way to bust dynamic-route page HTML (see scripts/prompts/s3-page-cache-bust.md).
+        revalidate_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["s3:DeleteObject"],
+                resources=[f"{frontend_bucket.bucket_arn}/cache/*"],
+            )
+        )
         revalidate_fn = PythonFunction(
             self,
             "RevalidateFrontendFn",
@@ -1008,6 +1016,8 @@ class ComputeStack(cdk.Stack):
                 POWERTOOLS_METRICS_NAMESPACE="SteamPulse",
                 FRONTEND_BASE_URL=self.frontend_fn_url.url,
                 REVALIDATE_TOKEN_PARAM=revalidate_token_param,
+                FRONTEND_BUCKET=frontend_bucket.bucket_name,
+                CACHE_BUCKET_KEY_PREFIX=f"cache/{self.node.try_get_context('build-id') or 'local'}/",
             ),
         )
         cdk.Tags.of(revalidate_fn).add("steampulse:service", "frontend")

--- a/scripts/prompts/s3-page-cache-bust.md
+++ b/scripts/prompts/s3-page-cache-bust.md
@@ -1,0 +1,128 @@
+# Direct S3 Page-Cache Bust (Workaround for OpenNext Dynamic-Route Limitation)
+
+## Context
+
+After landing all four prior cache PRs (`feature/game-report-cache-invalidation` → `feature/opennext-revalidation-pipeline` → `feature/pin-next-build-id` → `feature/revalidate-page-and-tag`), end-to-end production testing proved the loop **still doesn't bust the rendered page HTML**.
+
+Hands-on diagnostics:
+
+- `revalidateTag('game-${appid}', 'max')` writes a fresh `revalidatedAt` to DynamoDB → confirmed in the table → page still `HIT`.
+- `revalidatePath('/games/${appid}/${slug}')` runs without error → no DynamoDB write happens for that path → page still `HIT`.
+- Manual `aws s3 rm cache/{BUILD_ID}/{BUILD_ID}/games/{appid}/{slug}.cache` → next hit is `MISS` → re-renders fresh → next hit is `HIT` ✅.
+
+**Root cause** (OpenNext architectural limitation): `dynamodb-cache.json` is only pre-populated with `_N_T_/<route>` entries for routes whose paths are known at build time. Dynamic routes with empty `generateStaticParams` (`/games/[appid]/[slug]`) get *zero* page-tag entries. So neither `revalidateTag` nor `revalidatePath` has anything to mark stale at the page-cache level. The `__fetch/...` entries do get tagged at runtime (and `revalidateTag` correctly busts them), but the page HTML lives in S3 with no DynamoDB linkage and persists indefinitely.
+
+This is the *fifth* loop revealed by testing. Each prior fix was correct in isolation. The only reliable way to bust the dynamic-page S3 cache is to delete the file directly.
+
+**Goal**: extend `RevalidateFrontendFn` to also `s3:DeleteObject` the page cache file (and its `.meta` companion) for `/games/${appid}/${slug}` after the existing `/api/revalidate` POST succeeds. Two side effects per message; both must succeed for the message to ack.
+
+**Non-goal**: removing `revalidateTag`/`revalidatePath`. They remain useful (tag busts the shared fetches so the re-render gets fresh data; path call is a no-op today but costs nothing and stays defensive against future OpenNext fixes). Just add the S3 delete.
+
+## Best-practice foundation
+
+- **OpenNext's S3 cache key format** (verified): `${CACHE_BUCKET_KEY_PREFIX}${NEXT_BUILD_ID}/games/${appid}/${slug}.cache` plus a `.cache.meta` companion. After `feature/pin-next-build-id`, both prefix and BUILD_ID equal the git short SHA — they're the same value, written once per deploy.
+- **`s3:DeleteObject` on a missing key is idempotent** — 204 No Content, no error. Safe to call when the page was never cached.
+- **Order matters slightly**: do `/api/revalidate` (busts fetches) *before* `s3:DeleteObject` (busts page). On the next request, the re-render then uses fresh fetches. Reverse order opens a microscopic race window where a request between delete and tag-bust could re-render with stale fetch data.
+- **Both calls must succeed** before the SQS message acks — partial success would leave the page entry stale-but-undeletable, which is exactly the bug we're fixing.
+
+## Design
+
+### 1. Env wiring on `RevalidateFrontendFn`
+
+`infra/stacks/compute_stack.py` — extend the existing `RevalidateFrontendFn` block:
+
+- Add env vars (so the Lambda can construct the S3 path at runtime):
+  ```python
+  FRONTEND_BUCKET=frontend_bucket.bucket_name,
+  CACHE_BUCKET_KEY_PREFIX=f"cache/{self.node.try_get_context('build-id') or 'local'}/",
+  ```
+  The prefix has to match `FrontendFn`'s value exactly so we point at the same files.
+- Grant S3 delete permission scoped to the cache prefix:
+  ```python
+  frontend_bucket.grant_delete(revalidate_fn, f"cache/*")
+  ```
+  Or a tighter `grant` if `bucket.grant_delete` doesn't support prefix scoping — fall back to a manual `iam.PolicyStatement` with `s3:DeleteObject` on `arn:.../cache/*`.
+
+No DeliveryStack changes. Bucket already exists; the path glob covers all build IDs (so this works across deploys).
+
+### 2. Lambda handler — add S3 delete after POST
+
+`src/lambda-functions/lambda_functions/revalidate_frontend/handler.py`:
+
+- At cold start: `_FRONTEND_BUCKET = os.environ["FRONTEND_BUCKET"]`, `_CACHE_PREFIX = os.environ["CACHE_BUCKET_KEY_PREFIX"]`. Construct a `boto3.client("s3")` once.
+- After `_post_revalidate(appid, slug)` succeeds, call `_delete_page_cache(appid, slug)`:
+  ```python
+  build_id = _CACHE_PREFIX.removeprefix("cache/").rstrip("/")  # "b6d74d6"
+  base_key = f"{_CACHE_PREFIX}{build_id}/games/{appid}/{slug}"  # cache/b6d74d6/b6d74d6/games/3205380/omelet-you-cook-3205380
+  s3.delete_objects(
+      Bucket=_FRONTEND_BUCKET,
+      Delete={"Objects": [
+          {"Key": f"{base_key}.cache"},
+          {"Key": f"{base_key}.cache.meta"},
+      ]},
+  )
+  ```
+  `delete_objects` is idempotent at the per-key level: deleting non-existent keys returns 200 with no `Errors` array. We don't need to inspect `Errors` unless we want a strict mode.
+- Add a `PageCacheBust` metric increment alongside the existing `RevalidationsSucceeded`.
+- Failure handling unchanged — exceptions bubble, SQS retries, eventual DLQ.
+
+### 3. Tests
+
+`tests/handlers/test_revalidate_frontend_handler.py`:
+
+- Add `_FRONTEND_BUCKET` env + `mock_aws` S3 bucket in the autouse fixture (extend `_seed_ssm` to create the bucket).
+- Modify the happy-path test to assert `delete_objects` was called with the expected two keys (use `boto3.client("s3").list_objects_v2` after invocation, or inspect the moto bucket directly).
+- Add a "delete fails → batch failure" case (use `monkeypatch` to make the s3 client raise).
+- The existing token-failure / non-2xx HTTP / missing-slug tests stay valid — they short-circuit before reaching the S3 delete.
+
+### 4. Out of scope
+
+- Touching `/api/revalidate`, `frontend/lib/api.ts`, the page tsx, or any other PR's diff. Pure additive change to the Lambda + IAM.
+- CloudFront edge invalidation (separate prompt: `game-report-cloudfront-invalidation.md`).
+- Migrating off the workaround once OpenNext supports dynamic-route tag invalidation upstream — file an issue and revisit.
+
+## Critical files
+
+**Edit:**
+- `infra/stacks/compute_stack.py` — add `FRONTEND_BUCKET` + `CACHE_BUCKET_KEY_PREFIX` env vars and `s3:DeleteObject` grant on the existing `RevalidateFrontendFn` block.
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py` — add `_delete_page_cache(appid, slug)`; call after `_post_revalidate`; add metric.
+- `tests/handlers/test_revalidate_frontend_handler.py` — extend fixture for S3; assert delete keys; add failure case.
+
+**Reference (no edits):**
+- `frontend/.open-next/server-functions/default/...` — confirms the S3 path format used by OpenNext for cached pages.
+- `infra/stacks/compute_stack.py` (existing FrontendFn block) — `CACHE_BUCKET_KEY_PREFIX` is the same value we mirror onto the revalidate Lambda.
+
+## Verification
+
+**Local**:
+```sh
+poetry run pytest tests/handlers/test_revalidate_frontend_handler.py
+poetry run pytest tests/infra/
+ENVIRONMENT=production poetry run cdk synth --quiet
+```
+All green; synth includes the new IAM policy + env vars on `RevalidateFrontendFn`.
+
+**Production** (after deploy):
+1. Hit `/games/3205380/omelet-you-cook-3205380` via Function URL → `MISS` then `HIT`.
+2. Synthetic invoke `RevalidateFrontendFn` (payload includes appid + slug).
+3. Confirm `RevalidateFrontendFn` logs show both the POST success **and** the S3 delete success.
+4. Confirm S3 file is gone: `aws s3 ls s3://steampulse-frontend-production/cache/<BUILD_ID>/<BUILD_ID>/games/3205380/` → empty.
+5. Hit the page again → `MISS` (re-render triggered).
+6. Hit a third time → `HIT` with the just-rendered fresh content.
+7. Bonus: trigger a real re-analysis via Step Functions; confirm steps 3–6 happen automatically.
+
+**Rollback**: revert the handler changes and the IAM/env additions in ComputeStack. The `/api/revalidate` POST keeps firing (no-op for the page cache, as we already proved). Manual `invalidate-cdn.sh` remains as the escape hatch.
+
+## Why this is "the right end state for now"
+
+- **Closes the loop end-to-end** — first time in five PRs that a re-analysis actually changes what viewers see (origin-side; CloudFront edge invalidation is the separate next step).
+- **No OpenNext fork or custom adapter** — works around the limitation with one IAM grant + a `delete_objects` call.
+- **Forward-compatible** — when OpenNext eventually supports dynamic-route page invalidation natively, we can remove the S3 delete and the system keeps working via `revalidatePath`.
+- **Cheap** — `delete_objects` is fractions of a cent per call; no new infra.
+
+## Sources
+
+- [OpenNext caching internals (cache key layout)](https://opennext.js.org/aws/inner_workings/caching)
+- [OpenNext Tag Cache override (pre-population requirement)](https://opennext.js.org/aws/config/overrides/tag_cache)
+- [boto3 `delete_objects` docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_objects.html)
+- [Next.js revalidatePath (still called for forward-compat)](https://nextjs.org/docs/app/api-reference/functions/revalidatePath)

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -23,10 +23,27 @@ _REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
     decrypt=True,
 )
 _FRONTEND_BUCKET: str = os.environ["FRONTEND_BUCKET"]
-_CACHE_KEY_PREFIX: str = os.environ["CACHE_BUCKET_KEY_PREFIX"]
+
+
+def _parse_cache_key_prefix(prefix: str) -> tuple[str, str]:
+    """Validate "cache/{BUILD_ID}/" and return (prefix, build_id)."""
+    if not prefix.startswith("cache/") or not prefix.endswith("/"):
+        raise ValueError(
+            f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}"
+        )
+    build_id = prefix[len("cache/"): -1]
+    if not build_id or "/" in build_id:
+        raise ValueError(
+            f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}"
+        )
+    return prefix, build_id
+
+
 # OpenNext writes pages under cache/{BUILD_ID}/{BUILD_ID}/... — the prefix
 # is "cache/{BUILD_ID}/" and the inner BUILD_ID matches after pinning.
-_BUILD_ID: str = _CACHE_KEY_PREFIX.removeprefix("cache/").rstrip("/")
+_CACHE_KEY_PREFIX, _BUILD_ID = _parse_cache_key_prefix(
+    os.environ["CACHE_BUCKET_KEY_PREFIX"]
+)
 _HTTP_TIMEOUT_SECONDS = 5.0
 _s3 = boto3.client("s3")
 
@@ -74,7 +91,7 @@ def _delete_page_cache(appid: int, slug: str) -> None:
     in DynamoDB, so revalidatePath/revalidateTag don't bust them.
     """
     base_key = f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/games/{appid}/{slug}"
-    _s3.delete_objects(
+    response = _s3.delete_objects(
         Bucket=_FRONTEND_BUCKET,
         Delete={
             "Objects": [
@@ -83,6 +100,11 @@ def _delete_page_cache(appid: int, slug: str) -> None:
             ]
         },
     )
+    # delete_objects returns 200 even when individual keys fail (e.g.,
+    # AccessDenied). Surface those so SQS retries / DLQ catches them.
+    errors = response.get("Errors") or []
+    if errors:
+        raise RuntimeError(f"S3 delete_objects errors: {errors}")
 
 
 @logger.inject_lambda_context(clear_state=True)

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -3,6 +3,7 @@
 import json
 import os
 
+import boto3
 import httpx
 from aws_lambda_powertools import Logger, Metrics
 from aws_lambda_powertools.metrics import MetricUnit
@@ -21,7 +22,13 @@ _REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
     os.environ["REVALIDATE_TOKEN_PARAM"],
     decrypt=True,
 )
+_FRONTEND_BUCKET: str = os.environ["FRONTEND_BUCKET"]
+_CACHE_KEY_PREFIX: str = os.environ["CACHE_BUCKET_KEY_PREFIX"]
+# OpenNext writes pages under cache/{BUILD_ID}/{BUILD_ID}/... — the prefix
+# is "cache/{BUILD_ID}/" and the inner BUILD_ID matches after pinning.
+_BUILD_ID: str = _CACHE_KEY_PREFIX.removeprefix("cache/").rstrip("/")
 _HTTP_TIMEOUT_SECONDS = 5.0
+_s3 = boto3.client("s3")
 
 # Lazy-init so connections pool across records and warm invocations.
 _http_client: httpx.Client | None = None
@@ -60,6 +67,24 @@ def _post_revalidate(appid: int, slug: str) -> None:
     response.raise_for_status()
 
 
+def _delete_page_cache(appid: int, slug: str) -> None:
+    """Delete the OpenNext S3 page cache file (and .meta) for this game.
+
+    Required workaround: OpenNext doesn't tag dynamic-route page entries
+    in DynamoDB, so revalidatePath/revalidateTag don't bust them.
+    """
+    base_key = f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/games/{appid}/{slug}"
+    _s3.delete_objects(
+        Bucket=_FRONTEND_BUCKET,
+        Delete={
+            "Objects": [
+                {"Key": f"{base_key}.cache"},
+                {"Key": f"{base_key}.cache.meta"},
+            ]
+        },
+    )
+
+
 @logger.inject_lambda_context(clear_state=True)
 @metrics.log_metrics(capture_cold_start_metric=True)
 def handler(event: dict, _context: LambdaContext) -> dict:
@@ -70,7 +95,9 @@ def handler(event: dict, _context: LambdaContext) -> dict:
         try:
             appid, slug = _extract_event(record)
             _post_revalidate(appid, slug)
+            _delete_page_cache(appid, slug)
             metrics.add_metric(name="RevalidationsSucceeded", unit=MetricUnit.Count, value=1)
+            metrics.add_metric(name="PageCacheBust", unit=MetricUnit.Count, value=1)
             logger.info("Revalidated", extra={"appid": appid, "slug": slug})
         except Exception:
             logger.exception("Failed to revalidate", extra={"message_id": message_id})

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -14,6 +14,9 @@ from tests.conftest import MockLambdaContext
 _FRONTEND_BASE_URL = "https://frontend.example.lambda-url.us-west-2.on.aws"
 _REVALIDATE_TOKEN_PARAM = "/steampulse/test/frontend/revalidate-token"
 _TOKEN = "test-token-abc123"
+_FRONTEND_BUCKET = "test-frontend-bucket"
+_CACHE_KEY_PREFIX = "cache/test-build/"
+_BUILD_ID = "test-build"
 
 
 @pytest.fixture(autouse=True)
@@ -29,10 +32,12 @@ def _reset_module_state() -> None:
 def _env() -> None:
     os.environ["FRONTEND_BASE_URL"] = _FRONTEND_BASE_URL
     os.environ["REVALIDATE_TOKEN_PARAM"] = _REVALIDATE_TOKEN_PARAM
+    os.environ["FRONTEND_BUCKET"] = _FRONTEND_BUCKET
+    os.environ["CACHE_BUCKET_KEY_PREFIX"] = _CACHE_KEY_PREFIX
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
-def _seed_ssm() -> None:
+def _seed_ssm_and_bucket() -> None:
     ssm = boto3.client("ssm", region_name="us-east-1")
     ssm.put_parameter(
         Name=_REVALIDATE_TOKEN_PARAM,
@@ -40,11 +45,30 @@ def _seed_ssm() -> None:
         Type="String",
         Overwrite=True,
     )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=_FRONTEND_BUCKET)
+
+
+def _cache_key(appid: int, slug: str) -> str:
+    return f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/games/{appid}/{slug}"
+
+
+def _put_page_cache(appid: int, slug: str) -> None:
+    s3 = boto3.client("s3", region_name="us-east-1")
+    base = _cache_key(appid, slug)
+    s3.put_object(Bucket=_FRONTEND_BUCKET, Key=f"{base}.cache", Body=b"<html/>")
+    s3.put_object(Bucket=_FRONTEND_BUCKET, Key=f"{base}.cache.meta", Body=b"{}")
+
+
+def _page_cache_keys_present(appid: int, slug: str) -> bool:
+    s3 = boto3.client("s3", region_name="us-east-1")
+    resp = s3.list_objects_v2(Bucket=_FRONTEND_BUCKET, Prefix=_cache_key(appid, slug))
+    return resp.get("KeyCount", 0) > 0
 
 
 def _get_module() -> Any:
     """Re-seed SSM and reset the lazy http client between tests."""
-    _seed_ssm()
+    _seed_ssm_and_bucket()
     import lambda_functions.revalidate_frontend.handler as h
 
     h._http_client = None
@@ -105,13 +129,18 @@ def _multi_record_event(records: list[tuple[int, str]]) -> dict:
 
 
 @mock_aws
-def test_happy_path_posts_revalidate_with_token_appid_slug(httpx_mock: HTTPXMock) -> None:
+def test_happy_path_posts_revalidate_and_deletes_s3_page_cache(
+    httpx_mock: HTTPXMock,
+) -> None:
     httpx_mock.add_response(
         method="POST",
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 12345, "slug": _slug(12345), "now": 0},
     )
     handler = _get_module()
+    _put_page_cache(12345, _slug(12345))
+    assert _page_cache_keys_present(12345, _slug(12345))
+
     result = handler.handler(_sns_wrapped_event(12345), MockLambdaContext())
 
     assert result == {"batchItemFailures": []}
@@ -120,6 +149,30 @@ def test_happy_path_posts_revalidate_with_token_appid_slug(httpx_mock: HTTPXMock
     req = requests[0]
     assert req.headers["x-revalidate-token"] == _TOKEN
     assert json.loads(req.content) == {"appid": 12345, "slug": _slug(12345)}
+    assert not _page_cache_keys_present(12345, _slug(12345)), (
+        "page cache file + .meta should be deleted from S3"
+    )
+
+
+@mock_aws
+def test_s3_delete_failure_returns_batch_item_failure(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 1, "slug": _slug(1), "now": 0},
+    )
+    handler = _get_module()
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("simulated S3 outage")
+
+    monkeypatch.setattr(handler._s3, "delete_objects", _boom)
+    result = handler.handler(_sns_wrapped_event(1, message_id="s3-fail"), MockLambdaContext())
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "s3-fail"}]}
 
 
 @mock_aws

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -176,6 +176,45 @@ def test_s3_delete_failure_returns_batch_item_failure(
 
 
 @mock_aws
+def test_s3_per_key_errors_returns_batch_item_failure(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delete_objects returns 200 with `Errors` list — must surface as failure."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 2, "slug": _slug(2), "now": 0},
+    )
+    handler = _get_module()
+
+    def _partial_failure(*_args: object, **_kwargs: object) -> dict:
+        return {
+            "Deleted": [{"Key": "ok-key"}],
+            "Errors": [{"Key": "bad-key", "Code": "AccessDenied"}],
+        }
+
+    monkeypatch.setattr(handler._s3, "delete_objects", _partial_failure)
+    result = handler.handler(
+        _sns_wrapped_event(2, message_id="s3-partial"), MockLambdaContext()
+    )
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "s3-partial"}]}
+
+
+def test_module_load_rejects_malformed_cache_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail fast at cold start if CACHE_BUCKET_KEY_PREFIX is wrong shape."""
+    import sys
+
+    monkeypatch.setenv("CACHE_BUCKET_KEY_PREFIX", "not-cache/foo/")
+    sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
+    with pytest.raises(ValueError, match="must match 'cache/"):
+        import lambda_functions.revalidate_frontend.handler  # noqa: F401
+
+
+@mock_aws
 def test_non_2xx_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         method="POST",

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -202,12 +202,16 @@ def test_s3_per_key_errors_returns_batch_item_failure(
     assert result == {"batchItemFailures": [{"itemIdentifier": "s3-partial"}]}
 
 
+@mock_aws
 def test_module_load_rejects_malformed_cache_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Fail fast at cold start if CACHE_BUCKET_KEY_PREFIX is wrong shape."""
     import sys
 
+    # Seed SSM so the token lookup at module load doesn't fail before reaching
+    # the prefix validation.
+    _seed_ssm_and_bucket()
     monkeypatch.setenv("CACHE_BUCKET_KEY_PREFIX", "not-cache/foo/")
     sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
     with pytest.raises(ValueError, match="must match 'cache/"):


### PR DESCRIPTION
Carefully check this PR!!  It implements promt at: scripts/prompts/s3-page-cache-bust.md.

Specific things to verify:
- **This is the fifth and final loop in cache-until-changed**. Production testing of PR #134 (`revalidatePath` + `revalidateTag`) proved both Next.js APIs are no-ops for OpenNext-rendered dynamic-route page HTML — `dynamodb-cache.json` doesn't pre-populate page-tag entries for routes with empty `generateStaticParams`. Manual `aws s3 rm` of the cache file was the only thing that actually invalidated the page. This PR automates that.
- **New IAM permission**: `s3:DeleteObject` on `<frontend_bucket>/cache/*` for the `RevalidateFrontendFn` role. Scoped to the cache prefix only — the Lambda can't delete other bucket contents.
- **Two new env vars on `RevalidateFrontendFn`**: `FRONTEND_BUCKET` and `CACHE_BUCKET_KEY_PREFIX`. The latter mirrors the same expression used by `FrontendFn` (`f"cache/{self.node.try_get_context('build-id') or 'local'}/"`) so both Lambdas address the same files. Confirm they stay in lockstep on every deploy.
- **`CACHE_BUCKET_KEY_PREFIX` validated at module load** (`_parse_cache_key_prefix`): must match `cache/{BUILD_ID}/`. Fails fast at cold start if the format ever drifts, instead of silently constructing wrong keys.
- **Cache key construction**: `{CACHE_KEY_PREFIX}{BUILD_ID}/games/{appid}/{slug}.cache` and `.cache.meta`. The doubled BUILD_ID is OpenNext's path layout (verified in S3); both halves equal the git short SHA after `feature/pin-next-build-id`.
- **`delete_objects` per-key error handling**: boto3 returns 200 even when individual keys fail (e.g., AccessDenied). The handler inspects `response["Errors"]` and raises if non-empty so SQS retries fire and the message lands on the DLQ — not silently ACKed.
- **`delete_objects` on missing keys is idempotent** — non-existent keys land in `Deleted`, not `Errors`. Safe when a page was never cached.
- **`revalidateTag`/`revalidatePath` calls in `/api/revalidate` stay**: `revalidateTag` still busts the underlying fetch cache so the next re-render gets fresh data; `revalidatePath` is a no-op today but is forward-compat for if/when OpenNext fixes dynamic-route invalidation upstream.
- **Tests**: happy path pre-writes a fake cache file and asserts both `.cache` and `.cache.meta` are gone after the handler runs. New cases cover (a) S3 client raising → batch failure, (b) per-key `Errors` in response → batch failure, (c) malformed `CACHE_BUCKET_KEY_PREFIX` → import-time `ValueError`.
- **Out-of-band `scripts/deploy.sh` change** (added `rm -rf .next .open-next` before `npm run build:open-next`) is *not* in this PR — separate fix for the stale-build-state issue from earlier today; ship separately.