### PR TITLE
feature/game-report-cloudfront-invalidation: invalidate CloudFront edge after revalidate POST

### DIFF
--- a/docs/frontend-data-flow.txt
+++ b/docs/frontend-data-flow.txt
@@ -133,10 +133,12 @@
     │  writes the fresh entry back to S3 + DynamoDB
     │  subsequent requests now return HIT with fresh content
     ▼
-  CloudFront edge HTML cache  ⚠ NOT INVALIDATED by this loop
-    Tracked in scripts/prompts/game-report-cloudfront-invalidation.md.
-    Until that lands, CloudFront edges hold stale HTML up to s-maxage
-    (1 year). Manual flush: scripts/invalidate-cdn.sh.
+  CloudFront edge HTML cache  ✓ invalidated by this loop
+    RevalidateFrontendFn issues `cloudfront:CreateInvalidation` for
+    `/games/{appid}/*` after the /api/revalidate POST + S3 page-cache
+    delete succeed. One invalidation per SQS batch (deterministic
+    CallerReference from sorted messageIds → SQS retries reuse the
+    existing invalidation). Manual escape hatch: scripts/invalidate-cdn.sh.
 
 
 ╔══════════════════════════════════════════════════════════════════════╗

--- a/docs/frontend-data-flow.txt
+++ b/docs/frontend-data-flow.txt
@@ -180,3 +180,40 @@
         │
         └── fetch("" + "/api/games") = fetch("/api/games")
             CloudFront routes /api/* → ApiFn
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║         GOTCHAS — non-obvious requirements for cache-until-changed   ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  Each of these was discovered by end-to-end debugging in prod. Removing
+  any one re-breaks the loop.
+
+  1. Pin Next BUILD_ID to git SHA (next.config.ts → generateBuildId).
+     Without it, every deploy gets a new BUILD_ID; tag namespaces drift
+     and revalidateTag writes to a different namespace than reads.
+
+  2. Deploy OpenNext's revalidation queue + Lambda (compute_stack.py).
+     OpenNext enqueues stale-page re-render requests to an internal SQS
+     queue. Without the consumer, the cache stays STALE forever.
+
+  3. Add `generateStaticParams() => []` to dynamic routes (next 16+).
+     Without it the route is fully dynamic SSR with no ISR; the
+     `revalidate` export is silently ignored.
+
+  4. Direct S3 delete is the ONLY way to bust dynamic-route page HTML.
+     OpenNext doesn't pre-populate page-tag entries for dynamic routes,
+     so neither `revalidatePath` nor `revalidateTag` invalidates the
+     rendered HTML in S3. RevalidateFrontendFn must `s3:DeleteObject`
+     the .cache and .cache.meta files directly.
+
+  5. Clean .next/.open-next before every build (deploy.sh).
+     Stale build artifacts cause sporadic Turbopack font-resolution
+     and missing-build-manifest errors during open-next bundling.
+
+  Regression test: scripts/smoke/cache_invalidation.sh covers the full
+  origin-side loop (prime → invalidate → S3 delete → re-render). Run
+  after every prod deploy:
+      bash scripts/smoke/cache_invalidation.sh
+  Exits non-zero on any regression. Wire into scripts/deploy.sh as a
+  final post-deploy step.

--- a/docs/frontend-data-flow.txt
+++ b/docs/frontend-data-flow.txt
@@ -142,6 +142,269 @@
 
 
 ╔══════════════════════════════════════════════════════════════════════╗
+║       THE THREE CACHES — WHAT EACH ONE PROTECTS AGAINST              ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  Three caches stack between the browser and Postgres. Each protects a
+  different bottleneck:
+
+       Browser
+          │
+          ▼
+   ┌─────────────────────┐  CloudFront edge cache       skips Lambda
+   │  CloudFront PoP     │  (HTTP response — HTML +
+   │  (worldwide PoPs)   │   headers, keyed by URL)     <20ms TTFB
+   └─────────┬───────────┘
+             │ MISS / invalidated
+             ▼
+   ┌─────────────────────┐  OpenNext page cache         skips React render
+   │  FrontendFn (us-w-2)│  (rendered HTML in S3 at
+   │  └─ S3 .cache file  │   cache/{BUILD_ID}/<route>)
+   └─────────┬───────────┘
+             │ MISS / stale
+             ▼
+   ┌─────────────────────┐  OpenNext data cache         skips fetch + DB
+   │  React server render│  (fetch() results keyed
+   │  └─ DynamoDB lookup │   by tag in DynamoDB)
+   └─────────┬───────────┘
+             │ MISS
+             ▼
+   ┌─────────────────────┐
+   │  FastAPI ──► RDS    │  origin of truth
+   └─────────────────────┘
+
+  CloudFront's HTML cache policy has default_ttl=0; the per-page TTL is
+  driven entirely by the origin's `Cache-Control: s-maxage=N` header,
+  where N comes from `export const revalidate = N` on the page.
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║       PER-PAGE CACHE STRATEGY — time-based vs push-invalidate        ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  Two distinct strategies coexist. The page's `revalidate` value picks:
+
+  ┌────────────────────────────────┬──────────┬──────────┬─────────────┐
+  │ Page                           │ revalid. │ Edge TTL │ Strategy    │
+  ├────────────────────────────────┼──────────┼──────────┼─────────────┤
+  │ /                              │     300s │   5 min  │ time-based  │
+  │ /genre/[slug]                  │   3 600s │   1 hr   │ time-based  │
+  │ /tag/[slug]                    │   3 600s │   1 hr   │ time-based  │
+  │ /developer/[slug]              │  86 400s │   1 day  │ time-based  │
+  │ /publisher/[slug]              │  86 400s │   1 day  │ time-based  │
+  │ /games/[appid]/[slug]          │ 31536000 │   1 yr   │ push-inval. │
+  │ /sitemap.xml                   │   3 600s │   1 hr   │ time-based  │
+  │ /api/*                         │     —    │   none   │ never cache │
+  └────────────────────────────────┴──────────┴──────────┴─────────────┘
+
+  Time-based: cache holds for N seconds, then the next request after
+    expiry triggers revalidation against origin (stale-while-revalidate
+    semantics). Cheap, simple, no upstream signal needed.
+
+  Push-invalidate: cache holds ~forever, busted explicitly via the
+    pipeline in the previous section. Used for game reports because
+    re-analysis is a discrete event producing materially-different
+    content; viewers expect to see the LATEST report immediately.
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║       SCENARIO A — first viewer hits /genre/roguelike-deckbuilder    ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  Cold start (nobody has visited this genre page yet):
+
+    Browser ──► CloudFront PoP        MISS  (TTL 0, never seen)
+                    │ forward
+                    ▼
+                FrontendFn  (cold start)
+                    │
+                    ├─► S3 page cache MISS
+                    │
+                    ├─► React server-render
+                    │       │
+                    │       ├─► OpenNext data cache MISS
+                    │       │       │ fetch
+                    │       │       ▼
+                    │       │   FastAPI ─► Postgres
+                    │       │       │
+                    │       │       └─► data cache: STORE (tagged)
+                    │       │
+                    │       └─► render HTML
+                    │
+                    ├─► S3 page cache: STORE
+                    │
+                    └─► response: Cache-Control: s-maxage=3600, ...
+                    │
+    CloudFront PoP: STORE for 1h ─► Browser
+
+  Second viewer (same PoP, 30 min later):
+
+    Browser ──► CloudFront PoP   HIT  ─► response served, never touches
+                                         Lambda, S3, DynamoDB, RDS
+
+  61 minutes later:
+
+    Browser ──► CloudFront PoP   MISS  (s-maxage expired)
+                    │ forward
+                    ▼
+                FrontendFn
+                    │
+                    ├─► S3 page cache HIT but past `revalidate`
+                    │     │ serve stale immediately
+                    │     │ enqueue re-render to OpenNextRevalidationQueue
+                    │     │
+                    │     └─► return stale HTML
+                    │
+    CloudFront PoP: re-cache stale for another 1h
+    Browser: gets stale this request
+    Background: OpenNextRevalidationFn re-renders, refreshes both caches
+    Subsequent viewers: fresh content
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║   SCENARIO B — admin updates the description of a genre in the DB    ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  The DB is updated. NO upstream event signal exists for genre pages,
+  so NOTHING tells any cache. Each viewer sees this:
+
+    t=0 min   admin commits UPDATE in Postgres
+              │
+              ├─ Postgres:           ✓ FRESH
+              ├─ OpenNext data cache: ✗ stale (last fetched < 1h ago)
+              ├─ S3 page cache:       ✗ stale HTML
+              └─ CloudFront PoPs:     ✗ stale HTML at every PoP
+
+    t=15 min  Tokyo viewer
+              CloudFront Tokyo PoP: HIT → OLD content
+
+    t=55 min  Frankfurt viewer
+              CloudFront Frankfurt PoP: HIT → OLD content
+              (Tokyo and Frankfurt PoPs are independent)
+
+    t=61 min  São Paulo viewer (PoP s-maxage just expired)
+              CloudFront São Paulo: MISS → forward to FrontendFn
+              FrontendFn: S3 page cache HIT but past `revalidate`
+                          → serve stale + enqueue re-render
+              Viewer: still gets OLD this request
+              Background: re-render fetches fresh from Postgres
+                          updates data cache + S3 page cache
+
+    t=61–~120 min  Each PoP's cache expires independently;
+                   each MISS triggers an independent re-render check
+                   (the OpenNext page cache is now fresh, so the second
+                   PoP-MISS gets fresh HTML on the first try)
+
+  Worst-case staleness for a genre page = revalidate window (1h) + a few
+  minutes propagation across PoPs. For developer/publisher pages that's
+  up to 24h. Tolerated by design — these are browse-style pages where
+  hour-scale staleness is acceptable.
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║   SCENARIO C — re-analysis completes for a game report page          ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  This is the path the cache-until-changed pipeline (and this PR) covers
+  end-to-end:
+
+    t=0s     ReportReadyEvent { appid: 646570, slug: "slay-the-spire" }
+                │
+                ▼ SNS → SQS
+    t=1s     RevalidateFrontendFn picks up the message
+                │
+                ├─► POST /api/revalidate { appid, slug }
+                │   FrontendFn handles:
+                │     revalidatePath("/games/646570/slay-the-spire")
+                │     revalidateTag("game-646570", "max")
+                │     │
+                │     └─► OpenNext data cache: tag entries marked invalid
+                │
+                ├─► S3.delete_objects(.cache + .cache.meta)
+                │     │
+                │     └─► S3 page cache: GONE
+                │
+                └─► cloudfront.create_invalidation(["/games/646570/*"])
+                      │
+                      └─► CloudFront control plane propagates the
+                          invalidation marker to every PoP worldwide
+                          (typical: 30s, max: ~5min)
+
+    t=2-30s  Each PoP marks the path as invalid
+
+    First viewer post-invalidation (any PoP):
+
+      Browser ──► CloudFront PoP    MISS (invalidated)
+                      │
+                      ▼
+                  FrontendFn
+                      │
+                      ├─► S3 page cache MISS (deleted)
+                      │
+                      ├─► React server-render
+                      │       └─► data cache MISS (tag busted)
+                      │             │ fetch
+                      │             ▼
+                      │           FastAPI ─► fresh report from Postgres
+                      │
+                      └─► response: FRESH HTML
+                      │
+      CloudFront PoP: cache fresh HTML for 1y
+      Browser: FRESH content
+
+  End-to-end staleness: <30 seconds worst case across the whole world.
+  Compare to up-to-1-year before the cache-busting pipeline existed.
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║       SUMMARY — cascade and freshness guarantees                     ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+  Cache hit cascade per request (any page):
+
+    request
+      │
+      ▼
+    CloudFront PoP
+      │ HIT  ─► serve from edge, done. No Lambda invoked.
+      │ MISS ─► forward to FrontendFn
+              │
+              ▼
+            FrontendFn
+              │
+              ▼
+            S3 page cache
+              │ HIT  + within revalidate ─► serve cached HTML, done.
+              │ HIT  + past revalidate   ─► serve stale + queue re-render
+              │ MISS ─► render
+                       │
+                       ▼
+                     OpenNext data cache
+                       │ HIT  + tag valid   ─► reuse fetch result
+                       │ HIT  + tag invalid ─► refetch from FastAPI
+                       │ MISS ─► fetch from FastAPI ─► Postgres
+
+  Worst-case viewer-staleness by route (assuming hot caches, no
+  upstream invalidation other than what's wired):
+
+    ┌────────────────────────────────────┬─────────────────────────┐
+    │ Page                               │ Worst-case staleness    │
+    ├────────────────────────────────────┼─────────────────────────┤
+    │ /games/[appid]/[slug] (this PR)    │ <30 seconds             │
+    │ /                                  │   5 minutes             │
+    │ /genre/[slug], /tag/[slug]         │   1 hour + propagation  │
+    │ /developer/[slug], /publisher/...  │  24 hours + propagation │
+    │ /api/*                             │   real-time (no cache)  │
+    └────────────────────────────────────┴─────────────────────────┘
+
+  Extending push-invalidation to a non-report page (e.g. genre) would
+  require: (1) a domain event signal upstream (e.g. GenreUpdatedEvent),
+  (2) wire it through SQS → revalidateTag('genre-${slug}') + cloudfront
+  invalidate, (3) accept the additional ~$5–25/mo CloudFront invalidation
+  cost. Currently NOT wired; staleness window is tolerated by design.
+
+
+╔══════════════════════════════════════════════════════════════════════╗
 ║                     KEY ROUTING RULES (CloudFront)                   ║
 ╚══════════════════════════════════════════════════════════════════════╝
 

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -984,6 +984,14 @@ class ComputeStack(cdk.Stack):
                 ],
             )
         )
+        # Direct delete of the OpenNext page-cache file — the only reliable
+        # way to bust dynamic-route page HTML (see scripts/prompts/s3-page-cache-bust.md).
+        revalidate_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["s3:DeleteObject"],
+                resources=[f"{frontend_bucket.bucket_arn}/cache/*"],
+            )
+        )
         revalidate_fn = PythonFunction(
             self,
             "RevalidateFrontendFn",
@@ -1008,6 +1016,8 @@ class ComputeStack(cdk.Stack):
                 POWERTOOLS_METRICS_NAMESPACE="SteamPulse",
                 FRONTEND_BASE_URL=self.frontend_fn_url.url,
                 REVALIDATE_TOKEN_PARAM=revalidate_token_param,
+                FRONTEND_BUCKET=frontend_bucket.bucket_name,
+                CACHE_BUCKET_KEY_PREFIX=f"cache/{self.node.try_get_context('build-id') or 'local'}/",
             ),
         )
         cdk.Tags.of(revalidate_fn).add("steampulse:service", "frontend")

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -1043,6 +1043,9 @@ class ComputeStack(cdk.Stack):
                 batch_size=2,
                 max_batching_window=cdk.Duration.seconds(5),
                 report_batch_item_failures=True,
+                # Cap concurrent Lambdas (and thus concurrent CloudFront
+                # invalidations) below CloudFront's 15-per-distribution limit.
+                max_concurrency=10,
             )
         )
 

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -965,6 +965,7 @@ class ComputeStack(cdk.Stack):
         revalidate_token_param = (
             f"/steampulse/{env}/frontend/revalidate-token"
         )
+        distribution_id_param = f"/steampulse/{env}/delivery/distribution-id"
         revalidate_role = iam.Role(
             self,
             "RevalidateFrontendRole",
@@ -980,7 +981,9 @@ class ComputeStack(cdk.Stack):
                 actions=["ssm:GetParameter"],
                 resources=[
                     f"arn:aws:ssm:{self.region}:{self.account}"
-                    f":parameter{revalidate_token_param}"
+                    f":parameter{revalidate_token_param}",
+                    f"arn:aws:ssm:{self.region}:{self.account}"
+                    f":parameter{distribution_id_param}",
                 ],
             )
         )
@@ -990,6 +993,16 @@ class ComputeStack(cdk.Stack):
             iam.PolicyStatement(
                 actions=["s3:DeleteObject"],
                 resources=[f"{frontend_bucket.bucket_arn}/cache/*"],
+            )
+        )
+        # CloudFront edge invalidation — distribution ID is resolved at runtime
+        # so the resource ARN must be wildcarded.
+        revalidate_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["cloudfront:CreateInvalidation"],
+                resources=[
+                    f"arn:aws:cloudfront::{self.account}:distribution/*"
+                ],
             )
         )
         revalidate_fn = PythonFunction(
@@ -1016,6 +1029,7 @@ class ComputeStack(cdk.Stack):
                 POWERTOOLS_METRICS_NAMESPACE="SteamPulse",
                 FRONTEND_BASE_URL=self.frontend_fn_url.url,
                 REVALIDATE_TOKEN_PARAM=revalidate_token_param,
+                DISTRIBUTION_ID_PARAM=distribution_id_param,
                 FRONTEND_BUCKET=frontend_bucket.bucket_name,
                 CACHE_BUCKET_KEY_PREFIX=f"cache/{self.node.try_get_context('build-id') or 'local'}/",
             ),

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -99,6 +99,10 @@ if [[ "$SKIP_FRONTEND" == "false" ]]; then
     echo "▶ Step 1/4 — Building Next.js frontend (OpenNext)"
     cd "$REPO_ROOT/frontend"
     npm ci --silent
+    # Clean prior build artifacts: stale .next can produce confusing
+    # "Module not found: @vercel/turbopack-next/internal/font/..." or
+    # missing build-manifest.json errors during open-next bundling.
+    rm -rf .next .open-next
     npm run build:open-next
     cd "$REPO_ROOT"
     echo "✓ Frontend build complete"

--- a/scripts/prompts/exploration/packaging-strategy.md
+++ b/scripts/prompts/exploration/packaging-strategy.md
@@ -1,0 +1,324 @@
+# SteamPulse Packaging Strategy — From-Scratch Recommendation
+
+> **Status:** exploration. The user asked: throwing out current assumptions, what would a smart business operator do for packaging, given the constraints (1) free stuff, (2) paid stuff, (3) one-time-purchase PDFs? This is my honest answer after researching the competitive landscape and applying patio11-style pricing thinking.
+
+## TL;DR
+
+Stop selling $49/$149/$499 genre PDFs as the headline product. Restructure as:
+
+| Tier             | Product                            | Price            | Job-to-be-done                                |
+|------------------|------------------------------------|------------------|------------------------------------------------|
+| **Free**         | Every game page (SEO-indexed)      | $0               | Discovery, brand, traffic                       |
+| **Per-Game PDF** | Decision Pack (one-time)           | **$99**          | "Should I make/price/launch this game?"        |
+| **Per-Genre PDF**| Market Atlas (one-time)            | **$499**         | "Should we enter this genre? What's the market?" |
+| **Pro Sub**      | Studio Pass for indies             | **$79/mo · $790/yr** | "Ongoing competitive intel + unlimited Decision Packs" |
+| **Studio Sub**   | Multi-seat + API + atlases included| **$499/mo · $4,990/yr** | "Publisher/mid-studio depth + team usage"      |
+| **Enterprise**   | Custom (don't publish price)       | $2k–$10k/mo      | M&A screening, weekly delivered intel           |
+
+Key moves: **kill the $49 and $149 tiers** (signal cheapness, attract pathological customers), **enter the $79/mo competitive gap** (nobody is there), **price-anchor the subscription with the one-time PDF** ("$99/game OR $79/mo unlimited" is obvious math).
+
+---
+
+## How I got here
+
+### Competitive landscape (real prices)
+
+```
+   $0/mo ────────────── $25/mo ────────── $75/mo ────────── $500/mo ────────── $20k/yr
+   │                    │                  │                  │                  │
+   Steam Sentimeter     GameDiscoverCo     Gamalytic Pro      [GAP]              PitchBook
+   GameDevAnalytics     Plus ($19/mo)      ($75/mo)                              ($12k-40k/yr)
+   IMPRESS free                                                                    Bloomberg
+   VGInsights free      Gamalytic Starter  VGInsights Indie                      ($20k+/yr)
+                        ($25/mo)           (~$20/mo)
+                        Crunchbase Pro     
+                        ($49/mo equiv)     
+```
+
+**The gap is between $75/mo and enterprise.** Nobody offers serious-indie / small-studio analytics in the $79–$499/mo band. That's where SteamPulse can win — and where its differentiated data (audience overlap + ML modeling + LLM reports) actually justifies the price.
+
+### What patio11 / "smart operator" thinking says
+
+From McKenzie, Cohen, Sethi (paraphrased + applied):
+
+1. **Charge more.** Almost every founder underprices. Higher prices → better customers → less support → more profitable per logo.
+2. **Free plans are marketing, not monetization.** Free should be a customer acquisition channel, not a customer-success tier.
+3. **Don't compete on price** — that's a race to the bottom against well-funded incumbents. Compete on the audience that has *budget AND pain*.
+4. **Information products price by decision value, not data cost.** A pricing study from a consultant is $1,000–$5,000. A "should we greenlight" study is $10k–$50k. Your PDFs replace those.
+5. **Anchor higher tiers off lower tiers.** "$99 per game OR $79/mo unlimited" is the trick. The one-time price makes the subscription obvious math.
+6. **Skip the cheapest tier.** A $19 tier brings $19 problems. Set the floor where serious customers live.
+
+### Stakeholder budget reality
+
+| Stakeholder            | Pre-launch decision value | Annual analytics budget |
+|------------------------|--------------------------|-------------------------|
+| Solo indie dev         | $20k–$200k (their savings) | $0–$300/yr              |
+| Indie studio (2–10)    | $100k–$1M               | $300–$3,000/yr           |
+| Mid studio (10–50)     | $500k–$5M               | $3k–$25k/yr              |
+| Publisher (small)      | $2M–$20M+ portfolio      | $25k–$100k/yr            |
+| Investor / VC          | $50M+ fund               | $50k–$500k/yr            |
+
+The current $49 / $149 / $499 PDFs hit the bottom two and badly mismatch the upper three. The packaging below covers the full ladder.
+
+---
+
+## Recommended packaging in detail
+
+### Free tier — every game page (zero gating)
+
+**Job:** Drive SEO traffic, build brand trust, become the default "where I look up a Steam game's analytics."
+
+**Content:** Game card with health score, archetype label, top-3 strengths and frictions (LLM excerpt), 5 audience-overlap competitors, genre-space map position (small embed), genre-median time-to-milestone, hidden-gem flag if applicable. Public, indexable, shareable.
+
+**Why generous:** Every indie dev googles their own game and their competitors. If they land on SteamPulse and the page is rich, you've earned discovery. This is your acquisition channel.
+
+**What's *not* free:** The depth (full data, all 50 competitors, model confidence intervals, exports, comparisons, projections, custom queries).
+
+---
+
+### One-time PDFs — the productized info products
+
+#### Per-Game Decision Pack — $99
+
+**Job:** "I'm spending 18 months and $50k+ on this game. Should I, and how should I position it?"
+
+**Buyer:** Solo indie dev, marketer prepping a launch, consultant doing client research.
+
+**Content (everything for one game):**
+- Full LLM `GameReport` (all sections, no truncation)
+- Hedonic fair-value with confidence band + SHAP feature importance ("you're priced 19% below model fair value of $18.50; top drivers: tag X, platform Y")
+- Survival curve for your archetype + your projected lifecycle position
+- Time-to-milestone with P10/P50/P90 bands vs your cohort
+- 50-competitor positioning (audience-overlap + feature-similarity, with full deltas)
+- Top association rules for your tag combo
+- Vocabulary fingerprint vs genre norms
+- Anomaly flags + sentiment over/underperformance with feature drivers
+- Cohort z-score
+- Genre-space map with your game pinned
+
+**Why $99:** It's one consultant hour, one Steam asset purchase, lunch for the studio. Painless for anyone with a real game in development. Below $99 (e.g., $49) signals "amateur tool" and attracts customers who'll send you 12 support tickets. $99 says serious.
+
+**Sales hook:** "Replaces a $1,500 pricing study. Read it tonight."
+
+#### Per-Genre Market Atlas — $499
+
+**Job:** "Should our studio/portfolio enter this genre? What's the real market structure?"
+
+**Buyer:** Studio strategy lead, publisher acquisition team, investor analyst.
+
+**Content (everything for one genre):**
+- LLM `GenreSynthesis` (cross-genre themes, friction patterns, dev priorities)
+- Genre-space 2D map of all genre members (hero visual)
+- Niche opportunities (white-space tag combos)
+- Launch window optimizer (when to ship)
+- Tag association rules (what works, anti-patterns)
+- Cohort trajectories (how each release year is performing)
+- Genre identity drift (how the genre is changing year-on-year)
+- Survival curves by archetype
+- Revenue concentration (Gini coefficient + top-10% share)
+- Top 25 games, top 10 developers, top 10 franchises in genre with trajectories
+
+**Why $499:** A greenlight committee can expense it. A consultant can mark it up. It replaces a $5k–$15k market study from a research firm. At $499 it's "yes" without committee approval.
+
+**What was the $49 / $149 tier for?** Mostly customers who'd be a support burden. Drop them. The $99 Decision Pack absorbs the per-game intent; the $499 Atlas absorbs the per-genre intent.
+
+---
+
+### Subscriptions — for ongoing usage
+
+#### Pro — $79/month or $790/year
+
+**Job:** "I'm a serious indie dev / small studio and I look at competitor games every week."
+
+**Buyer:** Solo devs and 2–10 person studios with active development.
+
+**Content:**
+- Everything in the free tier
+- **Unlimited Per-Game Decision Pack downloads** (any game, any time)
+- Live dashboards (vs static PDFs)
+- Interactive Niche Finder, Launch Window Optimizer, Hedonic Pricing tool
+- Save/track: portfolio of "watched" games + competitor list
+- CSV export
+- Email digests (weekly genre summary)
+- Email alerts when competitor sentiment shifts (when alerting infra exists)
+
+**Annual pricing:** $790/yr = 2 months free. Drives prepay.
+
+**Anchoring math:** "$99 per game OR $79/mo for unlimited." Anyone analyzing >1 game per month picks the sub. This is the conversion engine.
+
+**Why $79 (not $19, not $49):** Patio11 territory — the $79 customer is serious, won't ask 47 support questions, will renew. $19/mo customers churn fast and cost more in support than they pay. Also leaves room above for Studio tier without compression.
+
+#### Studio — $499/month or $4,990/year
+
+**Job:** "We're a publisher or mid-studio. We need this for our team, with API access and depth."
+
+**Buyer:** 10+ person studios, small publishers, dev consultancies.
+
+**Content:**
+- Everything in Pro
+- **Per-Genre Market Atlas PDFs included** (any genre, on demand)
+- Up to 10 user seats
+- API access (programmatic pulls for internal tools)
+- Custom comparable-set definitions
+- Quarterly genre deep-dive emailed
+- Priority email support
+- White-label option for client reports (consultancy use)
+
+**Anchoring math:** "$499 per Atlas OR $499/mo for unlimited Atlases + Pro for the whole team." Any studio touching >1 genre per quarter picks the sub.
+
+#### Enterprise — Custom (don't publish price)
+
+**Job:** "We're an investor or major publisher. We want bespoke intelligence."
+
+**Buyer:** VCs, M&A teams, big publishers, strategic acquirers.
+
+**Content:**
+- Custom data pulls + bespoke reports
+- Acquisition target screening (anomaly detection cross-catalog)
+- Weekly/monthly delivered intelligence packets
+- White-glove onboarding + dedicated contact
+- Embargo on data publication for sensitive deals
+
+**Pricing:** $2k–$10k/month. Negotiated. The fact that you don't publish the price is the signal.
+
+---
+
+## Why this packaging is smart
+
+### Each tier has a clear, distinct buyer
+
+```
+   Solo indie    ──→  Free + occasional $99 Decision Pack
+   Active indie  ──→  Pro $79/mo (one Pack/mo math justifies it)
+   Studio        ──→  Studio $499/mo (one Atlas/quarter math justifies it)
+   Publisher/VC  ──→  Enterprise (decisions worth $1M+ each)
+```
+
+No tier cannibalizes the next.
+
+### Each price point anchors the next
+
+- $99/game → makes $79/mo subscription obvious (>1 game/mo and you save)
+- $499/genre → makes $499/mo Studio subscription obvious (1 atlas/mo and the rest is free)
+- Visible pricing on the first 3 tiers builds trust; opaque Enterprise pricing captures whales
+
+### The free tier is a marketing asset, not a product
+
+Every game page is SEO-bait. Devs google their own game; competitors look up each other; press references SteamPulse. Free isn't generosity — it's the customer acquisition cost.
+
+### Packaging mirrors the actual job-to-be-done
+
+- Free = "I'm browsing"
+- $99 PDF = "I'm making a specific decision NOW about ONE game"
+- $499 PDF = "I'm making a specific decision NOW about ONE genre"
+- $79/mo Sub = "I make these decisions all the time"
+- $499/mo Sub = "My team makes these decisions and we need API + depth"
+
+Mismatched packaging (e.g., forcing the Pro features into a $19 tier) attracts customers whose job-to-be-done isn't aligned with what you offer.
+
+---
+
+## What changes vs current assumptions
+
+| Current                                | Recommended                              | Why                                              |
+|----------------------------------------|------------------------------------------|--------------------------------------------------|
+| $49 / $149 / $499 genre PDF tiers      | Single $499 Per-Genre Market Atlas       | $49 is too cheap; signals low quality, attracts pathological customers |
+| No per-game paid product               | $99 Per-Game Decision Pack               | The killer use case; no competitor offers this   |
+| No subscription tier                   | $79/mo Pro + $499/mo Studio              | Recurring revenue; competitive gap at $79 band   |
+| No enterprise tier                     | Custom Enterprise (unpublished)          | Captures publisher/investor upside               |
+| Tier 2 add-ons gated by triggers       | Subscription absorbs add-on use cases    | Triggers are confusing; flat unlimited is clean  |
+
+The "Tier 2 add-ons gated by numerical triggers" idea (from the existing business model memo) was clever but adds cognitive load at purchase. Cleaner: the Pro subscription is unlimited everything; the trigger logic disappears.
+
+---
+
+## Revenue model (illustrative back-of-envelope)
+
+Assume year-2 catalog of 1,000 covered games + 50 covered genres + organic SEO traffic.
+
+| Source                          | Volume / month | Avg price | MRR |
+|---------------------------------|----------------|-----------|-----|
+| Per-Game PDFs                   | 50 sales       | $99       | $4,950 |
+| Per-Genre Atlases               | 5 sales        | $499      | $2,495 |
+| Pro subscriptions               | 100 active     | $79       | $7,900 |
+| Studio subscriptions            | 8 active       | $499      | $3,992 |
+| Enterprise                      | 2 active       | $4,000    | $8,000 |
+| **Total MRR**                   |                |           | **$27,337** |
+
+That's ~$328k ARR from a 1,000-game catalog with conservative conversion. The Pro subscription is the engine; the PDFs are the entry; Enterprise captures the upside.
+
+Compare to current $49/$149/$499 PDF model: same 50 sales/mo at $49 average = $2,450 MRR. The new packaging is **>10× revenue** at the same volume.
+
+---
+
+## Risks and tradeoffs
+
+1. **No $19 or $49 entry tier means losing some traffic to Gamalytic / GameDiscoverCo Plus.** That's intentional. Those customers are price-sensitive and high-support; let competitors have them.
+
+2. **$79/mo is harder to convert than $19/mo.** True. But the conversion math from a $99 Decision Pack ("you've already spent $99; another $79 unlocks unlimited and Live tools") does the work.
+
+3. **$499/mo Studio tier may seem high vs Gamalytic's $75/mo Pro.** Gamalytic's $75/mo doesn't include multi-seat, API, or report PDFs. The $499 is for a different buyer.
+
+4. **Building Enterprise sales takes founder time.** Yes — but 2–5 enterprise contracts at $4k+/mo are 25%+ of revenue with low support burden once landed.
+
+5. **Cannibalization risk between PDFs and Pro.** Actually a feature: the PDF is the entry point, the subscription is the destination. The math should clearly favor subscription for repeat users.
+
+6. **Pre-launch we have no proof points.** Counter: launch the $99 Decision Pack first (single SKU, simplest), prove it sells, then layer on subscription. Don't build all 5 tiers day one.
+
+---
+
+## Suggested launch sequence
+
+1. **Soft launch: free tier + $99 Per-Game Decision Pack.** One SKU. Prove people pay $99 for an automated decision pack. (~6 weeks)
+2. **Add: $499 Per-Genre Market Atlas.** Once a few studios have bought Decision Packs, sell them the Atlas. (~4 weeks)
+3. **Add: Pro $79/mo subscription.** When repeat PDF buyers emerge, give them the subscription option. The PDF anchors the price. (~6 weeks)
+4. **Add: Studio $499/mo.** When a Pro customer asks for multi-seat or API, you have the tier ready. (~4 weeks)
+5. **Add: Enterprise.** When an inbound publisher asks for custom data, take the meeting. Don't publish — quote.
+
+Total to fully-staged packaging: ~5 months. But revenue starts from week 6.
+
+---
+
+## What the existing roadmap unlocks for which tier
+
+Mapping the 31-feature `data-intelligence-roadmap.md` to the packaging:
+
+| Feature                              | Free | $99 PDF | $499 PDF | Pro $79 | Studio $499 |
+|--------------------------------------|------|---------|----------|---------|-------------|
+| 1 Game Health Score                  | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 2 Review Pattern Signals (top 2)     | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 2 Review Pattern Signals (full)      |      | ✓       |          | ✓       | ✓           |
+| 3 Archetype Clustering (label)       | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 3 Archetype Clustering (full sheet)  |      | ✓       | ✓        | ✓       | ✓           |
+| 4 Genre-Space Map (small embed)      | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 4 Genre-Space Map (interactive)      |      |         | ✓        | ✓       | ✓           |
+| 5 Time-to-Milestone (genre median)   | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 5 Time-to-Milestone (your projection)|      | ✓       |          | ✓       | ✓           |
+| 6 Tag Association Rules (top 3)      | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 6 Tag Association Rules (full)       |      | ✓       | ✓        | ✓       | ✓           |
+| 7 Niche Finder                       |      |         | ✓        | ✓       | ✓           |
+| 8 Launch Window Optimizer            |      | ✓       | ✓        | ✓       | ✓           |
+| 9 Hedonic Pricing (basic)            |      | ✓       |          | ✓       | ✓           |
+| 9 Hedonic Pricing (full SHAP)        |      | ✓       |          | ✓       | ✓           |
+| 10 Competitive Positioning (top 5)   | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 10 Competitive Positioning (top 50)  |      | ✓       |          | ✓       | ✓           |
+| 11 Survival Curves                   |      | ✓       | ✓        | ✓       | ✓           |
+| 14 Sentiment Predictor (badge)       | ✓    | ✓       | ✓        | ✓       | ✓           |
+| 14 Sentiment Predictor (SHAP)        |      | ✓       |          | ✓       | ✓           |
+| 15 Cohort Analysis                   |      | ✓       | ✓        | ✓       | ✓           |
+| 17 Revenue Intelligence (Gini)       |      |         | ✓        | ✓       | ✓           |
+| 19 Market Segmentation Map           |      |         | ✓        | ✓       | ✓           |
+| 20 Feature Similarity                |      | ✓       |          | ✓       | ✓           |
+| API access                           |      |         |          |         | ✓           |
+| Multi-seat                           |      |         |          |         | ✓           |
+| White-label                          |      |         |          |         | ✓           |
+
+Free tier is rich enough to drive SEO; PDFs are decision-complete; subscriptions add tools/scale/collaboration. Each upgrade has a clear "why."
+
+---
+
+## Bottom line
+
+The current $49/$149/$499 model is leaving money on the table at every level — too cheap for studios who'd pay $499/mo, missing the $99 per-game sweet spot for indies, and absent an enterprise tier. The packaging above is **denser revenue per customer, fewer pathological support cases, and aligned with how competitors price the adjacent market**.
+
+The single most important move: **launch the $99 Per-Game Decision Pack first**. It's one SKU, the highest-value deliverable, and the price-anchor that makes everything else obvious. Everything else can layer on once it sells.

--- a/scripts/prompts/s3-page-cache-bust.md
+++ b/scripts/prompts/s3-page-cache-bust.md
@@ -1,0 +1,128 @@
+# Direct S3 Page-Cache Bust (Workaround for OpenNext Dynamic-Route Limitation)
+
+## Context
+
+After landing all four prior cache PRs (`feature/game-report-cache-invalidation` → `feature/opennext-revalidation-pipeline` → `feature/pin-next-build-id` → `feature/revalidate-page-and-tag`), end-to-end production testing proved the loop **still doesn't bust the rendered page HTML**.
+
+Hands-on diagnostics:
+
+- `revalidateTag('game-${appid}', 'max')` writes a fresh `revalidatedAt` to DynamoDB → confirmed in the table → page still `HIT`.
+- `revalidatePath('/games/${appid}/${slug}')` runs without error → no DynamoDB write happens for that path → page still `HIT`.
+- Manual `aws s3 rm cache/{BUILD_ID}/{BUILD_ID}/games/{appid}/{slug}.cache` → next hit is `MISS` → re-renders fresh → next hit is `HIT` ✅.
+
+**Root cause** (OpenNext architectural limitation): `dynamodb-cache.json` is only pre-populated with `_N_T_/<route>` entries for routes whose paths are known at build time. Dynamic routes with empty `generateStaticParams` (`/games/[appid]/[slug]`) get *zero* page-tag entries. So neither `revalidateTag` nor `revalidatePath` has anything to mark stale at the page-cache level. The `__fetch/...` entries do get tagged at runtime (and `revalidateTag` correctly busts them), but the page HTML lives in S3 with no DynamoDB linkage and persists indefinitely.
+
+This is the *fifth* loop revealed by testing. Each prior fix was correct in isolation. The only reliable way to bust the dynamic-page S3 cache is to delete the file directly.
+
+**Goal**: extend `RevalidateFrontendFn` to also `s3:DeleteObject` the page cache file (and its `.meta` companion) for `/games/${appid}/${slug}` after the existing `/api/revalidate` POST succeeds. Two side effects per message; both must succeed for the message to ack.
+
+**Non-goal**: removing `revalidateTag`/`revalidatePath`. They remain useful (tag busts the shared fetches so the re-render gets fresh data; path call is a no-op today but costs nothing and stays defensive against future OpenNext fixes). Just add the S3 delete.
+
+## Best-practice foundation
+
+- **OpenNext's S3 cache key format** (verified): `${CACHE_BUCKET_KEY_PREFIX}${NEXT_BUILD_ID}/games/${appid}/${slug}.cache` plus a `.cache.meta` companion. After `feature/pin-next-build-id`, both prefix and BUILD_ID equal the git short SHA — they're the same value, written once per deploy.
+- **`s3:DeleteObject` on a missing key is idempotent** — 204 No Content, no error. Safe to call when the page was never cached.
+- **Order matters slightly**: do `/api/revalidate` (busts fetches) *before* `s3:DeleteObject` (busts page). On the next request, the re-render then uses fresh fetches. Reverse order opens a microscopic race window where a request between delete and tag-bust could re-render with stale fetch data.
+- **Both calls must succeed** before the SQS message acks — partial success would leave the page entry stale-but-undeletable, which is exactly the bug we're fixing.
+
+## Design
+
+### 1. Env wiring on `RevalidateFrontendFn`
+
+`infra/stacks/compute_stack.py` — extend the existing `RevalidateFrontendFn` block:
+
+- Add env vars (so the Lambda can construct the S3 path at runtime):
+  ```python
+  FRONTEND_BUCKET=frontend_bucket.bucket_name,
+  CACHE_BUCKET_KEY_PREFIX=f"cache/{self.node.try_get_context('build-id') or 'local'}/",
+  ```
+  The prefix has to match `FrontendFn`'s value exactly so we point at the same files.
+- Grant S3 delete permission scoped to the cache prefix:
+  ```python
+  frontend_bucket.grant_delete(revalidate_fn, f"cache/*")
+  ```
+  Or a tighter `grant` if `bucket.grant_delete` doesn't support prefix scoping — fall back to a manual `iam.PolicyStatement` with `s3:DeleteObject` on `arn:.../cache/*`.
+
+No DeliveryStack changes. Bucket already exists; the path glob covers all build IDs (so this works across deploys).
+
+### 2. Lambda handler — add S3 delete after POST
+
+`src/lambda-functions/lambda_functions/revalidate_frontend/handler.py`:
+
+- At cold start: `_FRONTEND_BUCKET = os.environ["FRONTEND_BUCKET"]`, `_CACHE_PREFIX = os.environ["CACHE_BUCKET_KEY_PREFIX"]`. Construct a `boto3.client("s3")` once.
+- After `_post_revalidate(appid, slug)` succeeds, call `_delete_page_cache(appid, slug)`:
+  ```python
+  build_id = _CACHE_PREFIX.removeprefix("cache/").rstrip("/")  # "b6d74d6"
+  base_key = f"{_CACHE_PREFIX}{build_id}/games/{appid}/{slug}"  # cache/b6d74d6/b6d74d6/games/3205380/omelet-you-cook-3205380
+  s3.delete_objects(
+      Bucket=_FRONTEND_BUCKET,
+      Delete={"Objects": [
+          {"Key": f"{base_key}.cache"},
+          {"Key": f"{base_key}.cache.meta"},
+      ]},
+  )
+  ```
+  `delete_objects` is idempotent at the per-key level: deleting non-existent keys returns 200 with no `Errors` array. We don't need to inspect `Errors` unless we want a strict mode.
+- Add a `PageCacheBust` metric increment alongside the existing `RevalidationsSucceeded`.
+- Failure handling unchanged — exceptions bubble, SQS retries, eventual DLQ.
+
+### 3. Tests
+
+`tests/handlers/test_revalidate_frontend_handler.py`:
+
+- Add `_FRONTEND_BUCKET` env + `mock_aws` S3 bucket in the autouse fixture (extend `_seed_ssm` to create the bucket).
+- Modify the happy-path test to assert `delete_objects` was called with the expected two keys (use `boto3.client("s3").list_objects_v2` after invocation, or inspect the moto bucket directly).
+- Add a "delete fails → batch failure" case (use `monkeypatch` to make the s3 client raise).
+- The existing token-failure / non-2xx HTTP / missing-slug tests stay valid — they short-circuit before reaching the S3 delete.
+
+### 4. Out of scope
+
+- Touching `/api/revalidate`, `frontend/lib/api.ts`, the page tsx, or any other PR's diff. Pure additive change to the Lambda + IAM.
+- CloudFront edge invalidation (separate prompt: `game-report-cloudfront-invalidation.md`).
+- Migrating off the workaround once OpenNext supports dynamic-route tag invalidation upstream — file an issue and revisit.
+
+## Critical files
+
+**Edit:**
+- `infra/stacks/compute_stack.py` — add `FRONTEND_BUCKET` + `CACHE_BUCKET_KEY_PREFIX` env vars and `s3:DeleteObject` grant on the existing `RevalidateFrontendFn` block.
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py` — add `_delete_page_cache(appid, slug)`; call after `_post_revalidate`; add metric.
+- `tests/handlers/test_revalidate_frontend_handler.py` — extend fixture for S3; assert delete keys; add failure case.
+
+**Reference (no edits):**
+- `frontend/.open-next/server-functions/default/...` — confirms the S3 path format used by OpenNext for cached pages.
+- `infra/stacks/compute_stack.py` (existing FrontendFn block) — `CACHE_BUCKET_KEY_PREFIX` is the same value we mirror onto the revalidate Lambda.
+
+## Verification
+
+**Local**:
+```sh
+poetry run pytest tests/handlers/test_revalidate_frontend_handler.py
+poetry run pytest tests/infra/
+ENVIRONMENT=production poetry run cdk synth --quiet
+```
+All green; synth includes the new IAM policy + env vars on `RevalidateFrontendFn`.
+
+**Production** (after deploy):
+1. Hit `/games/3205380/omelet-you-cook-3205380` via Function URL → `MISS` then `HIT`.
+2. Synthetic invoke `RevalidateFrontendFn` (payload includes appid + slug).
+3. Confirm `RevalidateFrontendFn` logs show both the POST success **and** the S3 delete success.
+4. Confirm S3 file is gone: `aws s3 ls s3://steampulse-frontend-production/cache/<BUILD_ID>/<BUILD_ID>/games/3205380/` → empty.
+5. Hit the page again → `MISS` (re-render triggered).
+6. Hit a third time → `HIT` with the just-rendered fresh content.
+7. Bonus: trigger a real re-analysis via Step Functions; confirm steps 3–6 happen automatically.
+
+**Rollback**: revert the handler changes and the IAM/env additions in ComputeStack. The `/api/revalidate` POST keeps firing (no-op for the page cache, as we already proved). Manual `invalidate-cdn.sh` remains as the escape hatch.
+
+## Why this is "the right end state for now"
+
+- **Closes the loop end-to-end** — first time in five PRs that a re-analysis actually changes what viewers see (origin-side; CloudFront edge invalidation is the separate next step).
+- **No OpenNext fork or custom adapter** — works around the limitation with one IAM grant + a `delete_objects` call.
+- **Forward-compatible** — when OpenNext eventually supports dynamic-route page invalidation natively, we can remove the S3 delete and the system keeps working via `revalidatePath`.
+- **Cheap** — `delete_objects` is fractions of a cent per call; no new infra.
+
+## Sources
+
+- [OpenNext caching internals (cache key layout)](https://opennext.js.org/aws/inner_workings/caching)
+- [OpenNext Tag Cache override (pre-population requirement)](https://opennext.js.org/aws/config/overrides/tag_cache)
+- [boto3 `delete_objects` docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_objects.html)
+- [Next.js revalidatePath (still called for forward-compat)](https://nextjs.org/docs/app/api-reference/functions/revalidatePath)

--- a/scripts/prompts/s3-page-cache-bust.md
+++ b/scripts/prompts/s3-page-cache-bust.md
@@ -63,7 +63,7 @@ No DeliveryStack changes. Bucket already exists; the path glob covers all build 
   )
   ```
   `delete_objects` is idempotent at the per-key level: deleting non-existent keys returns 200 with no `Errors` array. We don't need to inspect `Errors` unless we want a strict mode.
-- Add a `PageCacheBust` metric increment alongside the existing `RevalidationsSucceeded`.
+- Add a `PageCacheBust` metric increment alongside the existing `OriginRevalidationsSucceeded` (the per-record origin success counter; renamed from `RevalidationsSucceeded` in `feature/game-report-cloudfront-invalidation` once full-pipeline success became a separate `CdnInvalidations` metric).
 - Failure handling unchanged — exceptions bubble, SQS retries, eventual DLQ.
 
 ### 3. Tests

--- a/scripts/prompts/s3-page-cache-bust.md
+++ b/scripts/prompts/s3-page-cache-bust.md
@@ -78,7 +78,7 @@ No DeliveryStack changes. Bucket already exists; the path glob covers all build 
 ### 4. Out of scope
 
 - Touching `/api/revalidate`, `frontend/lib/api.ts`, the page tsx, or any other PR's diff. Pure additive change to the Lambda + IAM.
-- CloudFront edge invalidation (separate prompt: `game-report-cloudfront-invalidation.md`).
+- CloudFront edge invalidation (separate prompt: `game-report-cloudfront-invalidation.md` — *landed*; `RevalidateFrontendFn` now also issues `cloudfront:CreateInvalidation` after the S3 delete succeeds).
 - Migrating off the workaround once OpenNext supports dynamic-route tag invalidation upstream — file an issue and revisit.
 
 ## Critical files

--- a/scripts/smoke/cache_invalidation.sh
+++ b/scripts/smoke/cache_invalidation.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Post-deploy smoke test for the cache-until-changed loop.
+#
+# Verifies the end-to-end origin-side flow that took five PRs to land:
+#   1. Page is cached at the origin (S3 entry exists)
+#   2. Synthetic invoke of RevalidateFrontendFn deletes the S3 cache file
+#   3. Next visit re-renders and writes a new S3 entry
+#
+# Catches regressions in BUILD_ID alignment, OpenNext revalidation pipeline
+# wiring, route ISR classification, and the S3 file path layout — all of
+# which are OpenNext-specific and not covered by unit tests.
+#
+# Run after every prod deploy:
+#   bash scripts/smoke/cache_invalidation.sh
+#
+# Exit codes: 0 = pass, non-zero = regression (bash -e exits on first failure).
+
+set -euo pipefail
+
+ENV="${ENV:-production}"
+API_BASE="${API_BASE:-https://d1mamturmn55fm.cloudfront.net}"
+TIMEOUT_RERENDER_SECONDS="${TIMEOUT_RERENDER_SECONDS:-20}"
+
+step() { printf "\n▶ %s\n" "$*"; }
+fail() { printf "✗ %s\n" "$*" >&2; exit 1; }
+ok()   { printf "✓ %s\n" "$*"; }
+
+command -v aws >/dev/null  || fail "aws CLI required"
+command -v jq  >/dev/null  || fail "jq required (brew install jq)"
+command -v curl >/dev/null || fail "curl required"
+
+# ── Resolve deployed resources ────────────────────────────────────────────
+step "Resolving deployed resources in $ENV"
+REVAL_FN=$(aws lambda list-functions --query \
+  "Functions[?contains(FunctionName,'RevalidateFrontend')].FunctionName | [0]" \
+  --output text)
+[ -n "$REVAL_FN" ] && [ "$REVAL_FN" != "None" ] || fail "RevalidateFrontendFn not found"
+
+FRONTEND_FN=$(aws lambda list-functions --query \
+  "Functions[?contains(FunctionName,'FrontendFn') && !contains(FunctionName,'Revalidate')].FunctionName | [0]" \
+  --output text)
+[ -n "$FRONTEND_FN" ] && [ "$FRONTEND_FN" != "None" ] || fail "FrontendFn not found"
+
+FN_URL=$(aws lambda get-function-url-config \
+  --function-name "$FRONTEND_FN" --query FunctionUrl --output text)
+FN_URL="${FN_URL%/}"
+
+REVAL_ENV=$(aws lambda get-function-configuration --function-name "$REVAL_FN" \
+  --query 'Environment.Variables' --output json)
+BUCKET=$(echo "$REVAL_ENV" | jq -r '.FRONTEND_BUCKET')
+PREFIX=$(echo "$REVAL_ENV" | jq -r '.CACHE_BUCKET_KEY_PREFIX')
+BUILD_ID="${PREFIX#cache/}"
+BUILD_ID="${BUILD_ID%/}"
+[ -n "$BUCKET" ] && [ "$BUCKET" != "null" ] || fail "FRONTEND_BUCKET env missing on RevalidateFrontendFn"
+[ -n "$BUILD_ID" ] || fail "could not derive BUILD_ID from CACHE_BUCKET_KEY_PREFIX=$PREFIX"
+ok "RevalidateFrontendFn=$REVAL_FN, FrontendFn=$FRONTEND_FN, BUILD_ID=$BUILD_ID"
+
+# ── Pick a recently-analyzed game ──────────────────────────────────────────
+step "Picking a recently-analyzed game from $API_BASE"
+GAME_JSON=$(curl -fsS "$API_BASE/api/discovery/just_analyzed?limit=1")
+APPID=$(echo "$GAME_JSON" | jq -r '.games[0].appid')
+SLUG=$(echo "$GAME_JSON" | jq -r '.games[0].slug')
+[ "$APPID" != "null" ] && [ -n "$APPID" ] || fail "no analyzed games available"
+ok "appid=$APPID slug=$SLUG"
+
+PAGE_URL="$FN_URL/games/$APPID/$SLUG"
+S3_PAGE_PREFIX="${PREFIX}${BUILD_ID}/games/$APPID/"
+
+# ── Step 1: prime cache at origin ──────────────────────────────────────────
+step "Priming cache (two hits to ensure entry is written)"
+curl -fsS -o /dev/null -m 60 "$PAGE_URL"
+sleep 2
+curl -fsS -o /dev/null -m 60 "$PAGE_URL"
+sleep 1
+
+# ── Step 2: confirm S3 cache file exists ───────────────────────────────────
+PRE_LASTMOD=$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$S3_PAGE_PREFIX" \
+  --query "Contents[?ends_with(Key,'.cache')].LastModified | [0]" --output text)
+[ "$PRE_LASTMOD" != "None" ] && [ -n "$PRE_LASTMOD" ] || \
+  fail "page cache file not at s3://$BUCKET/$S3_PAGE_PREFIX after priming — route may not be ISR (check generateStaticParams + revalidate export)"
+ok "S3 cache file present (LastModified=$PRE_LASTMOD)"
+
+# ── Step 3: synthetic invoke of RevalidateFrontendFn ───────────────────────
+step "Invoking RevalidateFrontendFn synthetically"
+PAYLOAD_FILE=$(mktemp)
+trap 'rm -f "$PAYLOAD_FILE"' EXIT
+jq -nc --argjson appid "$APPID" --arg slug "$SLUG" --arg ts "$(date +%s)" '
+  {Records: [{
+    messageId: ("smoke-\($ts)"),
+    receiptHandle: "synthetic",
+    body: ({
+      Type: "Notification",
+      Message: ({
+        event_type: "report-ready",
+        appid: $appid,
+        game_name: $slug,
+        slug: $slug
+      } | tostring)
+    } | tostring)
+  }]}' > "$PAYLOAD_FILE"
+
+OUT_FILE=$(mktemp)
+trap 'rm -f "$PAYLOAD_FILE" "$OUT_FILE"' EXIT
+STATUS=$(aws lambda invoke --function-name "$REVAL_FN" \
+  --payload "fileb://$PAYLOAD_FILE" "$OUT_FILE" \
+  --cli-binary-format raw-in-base64-out --query StatusCode --output text)
+[ "$STATUS" = "200" ] || fail "Lambda invoke returned StatusCode=$STATUS"
+FAILURES=$(jq -r '.batchItemFailures | length' "$OUT_FILE")
+[ "$FAILURES" = "0" ] || fail "Lambda reported batchItemFailures: $(cat "$OUT_FILE")"
+ok "Lambda returned 200 with no batch failures"
+
+# ── Step 4: S3 cache file must be deleted ─────────────────────────────────
+sleep 1
+POST_LASTMOD=$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$S3_PAGE_PREFIX" \
+  --query "Contents[?ends_with(Key,'.cache')].LastModified | [0]" --output text 2>/dev/null || echo "None")
+[ "$POST_LASTMOD" = "None" ] || \
+  fail "S3 cache file still present after invocation (LastModified=$POST_LASTMOD) — s3:DeleteObject step is broken"
+ok "S3 cache file deleted by RevalidateFrontendFn"
+
+# ── Step 5: next visit must re-render and write a fresh entry ──────────────
+step "Polling for re-render (up to ${TIMEOUT_RERENDER_SECONDS}s)"
+DEADLINE=$(($(date +%s) + TIMEOUT_RERENDER_SECONDS))
+NEW_LASTMOD="None"
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  curl -fsS -o /dev/null -m 60 "$PAGE_URL"
+  sleep 2
+  NEW_LASTMOD=$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$S3_PAGE_PREFIX" \
+    --query "Contents[?ends_with(Key,'.cache')].LastModified | [0]" --output text 2>/dev/null || echo "None")
+  [ "$NEW_LASTMOD" != "None" ] && [ "$NEW_LASTMOD" != "$PRE_LASTMOD" ] && break
+done
+[ "$NEW_LASTMOD" != "None" ] && [ "$NEW_LASTMOD" != "$PRE_LASTMOD" ] || \
+  fail "page did not re-render within ${TIMEOUT_RERENDER_SECONDS}s (pre=$PRE_LASTMOD post=$NEW_LASTMOD)"
+ok "page re-rendered and re-cached (LastModified=$NEW_LASTMOD)"
+
+printf "\n✓ cache-until-changed loop verified end-to-end\n"

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -1,4 +1,9 @@
-"""SQS consumer that POSTs /api/revalidate to bust the game-${appid} tag."""
+"""SQS consumer that refreshes frontend game pages end-to-end.
+
+POSTs /api/revalidate to bust the game-${appid} tag, deletes the
+corresponding OpenNext S3 page-cache objects, and issues a CloudFront
+invalidation so stale HTML is not served at the edge.
+"""
 
 import hashlib
 import json
@@ -18,13 +23,22 @@ logger = Logger(service="revalidate-frontend")
 metrics = Metrics(namespace="SteamPulse", service="revalidate-frontend")
 metrics.set_default_dimensions(environment=_config.ENVIRONMENT)
 
+
+def _require_param(name: str, value: object) -> str:
+    """get_parameter typing is loose — fail loudly at cold start if it returns falsy."""
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"SSM parameter {name!r} resolved to empty/non-string: {value!r}")
+    return value
+
+
 _FRONTEND_BASE_URL: str = os.environ["FRONTEND_BASE_URL"].rstrip("/")
-_REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
+_REVALIDATE_TOKEN: str = _require_param(
     os.environ["REVALIDATE_TOKEN_PARAM"],
-    decrypt=True,
+    get_parameter(os.environ["REVALIDATE_TOKEN_PARAM"], decrypt=True),
 )
-_DISTRIBUTION_ID: str = get_parameter(  # type: ignore[assignment]
+_DISTRIBUTION_ID: str = _require_param(
     os.environ["DISTRIBUTION_ID_PARAM"],
+    get_parameter(os.environ["DISTRIBUTION_ID_PARAM"]),
 )
 _FRONTEND_BUCKET: str = os.environ["FRONTEND_BUCKET"]
 

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -1,9 +1,8 @@
 """SQS consumer that POSTs /api/revalidate to bust the game-${appid} tag."""
 
+import hashlib
 import json
 import os
-import time
-from uuid import uuid4
 
 import boto3
 import httpx
@@ -113,14 +112,19 @@ def _delete_page_cache(appid: int, slug: str) -> None:
         raise RuntimeError(f"S3 delete_objects errors: {errors}")
 
 
-def _invalidate_cdn(appids: list[int]) -> None:
-    """Issue one CloudFront invalidation covering /games/{appid}/* for each appid."""
-    paths = sorted({f"/games/{appid}/*" for appid in appids})
+def _invalidate_cdn(records: list[tuple[str, int]]) -> None:
+    """Issue one CloudFront invalidation covering /games/{appid}/* for the batch."""
+    paths = sorted({f"/games/{appid}/*" for _, appid in records})
+    # Deterministic CallerReference: same messageId set → same key, so an SQS
+    # retry after a successful CreateInvalidation reuses the existing one.
+    digest = hashlib.sha256(
+        "|".join(sorted(msg_id for msg_id, _ in records)).encode()
+    ).hexdigest()[:32]
     _cloudfront.create_invalidation(
         DistributionId=_DISTRIBUTION_ID,
         InvalidationBatch={
             "Paths": {"Quantity": len(paths), "Items": paths},
-            "CallerReference": f"revalidate-{int(time.time() * 1000)}-{uuid4().hex[:8]}",
+            "CallerReference": f"revalidate-{digest}",
         },
     )
 
@@ -150,7 +154,7 @@ def handler(event: dict, _context: LambdaContext) -> dict:
 
     if successful_records:
         try:
-            _invalidate_cdn([appid for _, appid in successful_records])
+            _invalidate_cdn(successful_records)
             metrics.add_metric(name="CdnInvalidations", unit=MetricUnit.Count, value=1)
             logger.info(
                 "CloudFront invalidation issued",

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -3,6 +3,7 @@
 import json
 import os
 
+import boto3
 import httpx
 from aws_lambda_powertools import Logger, Metrics
 from aws_lambda_powertools.metrics import MetricUnit
@@ -21,7 +22,30 @@ _REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
     os.environ["REVALIDATE_TOKEN_PARAM"],
     decrypt=True,
 )
+_FRONTEND_BUCKET: str = os.environ["FRONTEND_BUCKET"]
+
+
+def _parse_cache_key_prefix(prefix: str) -> tuple[str, str]:
+    """Validate "cache/{BUILD_ID}/" and return (prefix, build_id)."""
+    if not prefix.startswith("cache/") or not prefix.endswith("/"):
+        raise ValueError(
+            f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}"
+        )
+    build_id = prefix[len("cache/"): -1]
+    if not build_id or "/" in build_id:
+        raise ValueError(
+            f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}"
+        )
+    return prefix, build_id
+
+
+# OpenNext writes pages under cache/{BUILD_ID}/{BUILD_ID}/... — the prefix
+# is "cache/{BUILD_ID}/" and the inner BUILD_ID matches after pinning.
+_CACHE_KEY_PREFIX, _BUILD_ID = _parse_cache_key_prefix(
+    os.environ["CACHE_BUCKET_KEY_PREFIX"]
+)
 _HTTP_TIMEOUT_SECONDS = 5.0
+_s3 = boto3.client("s3")
 
 # Lazy-init so connections pool across records and warm invocations.
 _http_client: httpx.Client | None = None
@@ -60,6 +84,29 @@ def _post_revalidate(appid: int, slug: str) -> None:
     response.raise_for_status()
 
 
+def _delete_page_cache(appid: int, slug: str) -> None:
+    """Delete the OpenNext S3 page cache file (and .meta) for this game.
+
+    Required workaround: OpenNext doesn't tag dynamic-route page entries
+    in DynamoDB, so revalidatePath/revalidateTag don't bust them.
+    """
+    base_key = f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/games/{appid}/{slug}"
+    response = _s3.delete_objects(
+        Bucket=_FRONTEND_BUCKET,
+        Delete={
+            "Objects": [
+                {"Key": f"{base_key}.cache"},
+                {"Key": f"{base_key}.cache.meta"},
+            ]
+        },
+    )
+    # delete_objects returns 200 even when individual keys fail (e.g.,
+    # AccessDenied). Surface those so SQS retries / DLQ catches them.
+    errors = response.get("Errors") or []
+    if errors:
+        raise RuntimeError(f"S3 delete_objects errors: {errors}")
+
+
 @logger.inject_lambda_context(clear_state=True)
 @metrics.log_metrics(capture_cold_start_metric=True)
 def handler(event: dict, _context: LambdaContext) -> dict:
@@ -70,7 +117,9 @@ def handler(event: dict, _context: LambdaContext) -> dict:
         try:
             appid, slug = _extract_event(record)
             _post_revalidate(appid, slug)
+            _delete_page_cache(appid, slug)
             metrics.add_metric(name="RevalidationsSucceeded", unit=MetricUnit.Count, value=1)
+            metrics.add_metric(name="PageCacheBust", unit=MetricUnit.Count, value=1)
             logger.info("Revalidated", extra={"appid": appid, "slug": slug})
         except Exception:
             logger.exception("Failed to revalidate", extra={"message_id": message_id})

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import time
+from uuid import uuid4
 
 import boto3
 import httpx
@@ -21,6 +23,9 @@ _FRONTEND_BASE_URL: str = os.environ["FRONTEND_BASE_URL"].rstrip("/")
 _REVALIDATE_TOKEN: str = get_parameter(  # type: ignore[assignment]
     os.environ["REVALIDATE_TOKEN_PARAM"],
     decrypt=True,
+)
+_DISTRIBUTION_ID: str = get_parameter(  # type: ignore[assignment]
+    os.environ["DISTRIBUTION_ID_PARAM"],
 )
 _FRONTEND_BUCKET: str = os.environ["FRONTEND_BUCKET"]
 
@@ -46,6 +51,7 @@ _CACHE_KEY_PREFIX, _BUILD_ID = _parse_cache_key_prefix(
 )
 _HTTP_TIMEOUT_SECONDS = 5.0
 _s3 = boto3.client("s3")
+_cloudfront = boto3.client("cloudfront")
 
 # Lazy-init so connections pool across records and warm invocations.
 _http_client: httpx.Client | None = None
@@ -107,10 +113,23 @@ def _delete_page_cache(appid: int, slug: str) -> None:
         raise RuntimeError(f"S3 delete_objects errors: {errors}")
 
 
+def _invalidate_cdn(appids: list[int]) -> None:
+    """Issue one CloudFront invalidation covering /games/{appid}/* for each appid."""
+    paths = sorted({f"/games/{appid}/*" for appid in appids})
+    _cloudfront.create_invalidation(
+        DistributionId=_DISTRIBUTION_ID,
+        InvalidationBatch={
+            "Paths": {"Quantity": len(paths), "Items": paths},
+            "CallerReference": f"revalidate-{int(time.time() * 1000)}-{uuid4().hex[:8]}",
+        },
+    )
+
+
 @logger.inject_lambda_context(clear_state=True)
 @metrics.log_metrics(capture_cold_start_metric=True)
 def handler(event: dict, _context: LambdaContext) -> dict:
     batch_item_failures: list[dict[str, str]] = []
+    successful_records: list[tuple[str, int]] = []
 
     for record in event.get("Records", []):
         message_id = record.get("messageId", "")
@@ -121,10 +140,26 @@ def handler(event: dict, _context: LambdaContext) -> dict:
             metrics.add_metric(name="RevalidationsSucceeded", unit=MetricUnit.Count, value=1)
             metrics.add_metric(name="PageCacheBust", unit=MetricUnit.Count, value=1)
             logger.info("Revalidated", extra={"appid": appid, "slug": slug})
+            if message_id:
+                successful_records.append((message_id, appid))
         except Exception:
             logger.exception("Failed to revalidate", extra={"message_id": message_id})
             metrics.add_metric(name="RevalidationsFailed", unit=MetricUnit.Count, value=1)
             if message_id:
+                batch_item_failures.append({"itemIdentifier": message_id})
+
+    if successful_records:
+        try:
+            _invalidate_cdn([appid for _, appid in successful_records])
+            metrics.add_metric(name="CdnInvalidations", unit=MetricUnit.Count, value=1)
+            logger.info(
+                "CloudFront invalidation issued",
+                extra={"appids": [appid for _, appid in successful_records]},
+            )
+        except Exception:
+            logger.exception("CloudFront invalidation failed")
+            metrics.add_metric(name="CdnInvalidationsFailed", unit=MetricUnit.Count, value=1)
+            for message_id, _ in successful_records:
                 batch_item_failures.append({"itemIdentifier": message_id})
 
     return {"batchItemFailures": batch_item_failures}

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -155,14 +155,16 @@ def handler(event: dict, _context: LambdaContext) -> dict:
             appid, slug = _extract_event(record)
             _post_revalidate(appid, slug)
             _delete_page_cache(appid, slug)
-            metrics.add_metric(name="RevalidationsSucceeded", unit=MetricUnit.Count, value=1)
+            # Origin-side metrics: per-record, per-attempt. Re-emitted on
+            # SQS retry — full-pipeline success is CdnInvalidations below.
+            metrics.add_metric(name="OriginRevalidationsSucceeded", unit=MetricUnit.Count, value=1)
             metrics.add_metric(name="PageCacheBust", unit=MetricUnit.Count, value=1)
             logger.info("Revalidated", extra={"appid": appid, "slug": slug})
             if message_id:
                 successful_records.append((message_id, appid))
         except Exception:
             logger.exception("Failed to revalidate", extra={"message_id": message_id})
-            metrics.add_metric(name="RevalidationsFailed", unit=MetricUnit.Count, value=1)
+            metrics.add_metric(name="OriginRevalidationsFailed", unit=MetricUnit.Count, value=1)
             if message_id:
                 batch_item_failures.append({"itemIdentifier": message_id})
 

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -14,6 +14,8 @@ from tests.conftest import MockLambdaContext
 _FRONTEND_BASE_URL = "https://frontend.example.lambda-url.us-west-2.on.aws"
 _REVALIDATE_TOKEN_PARAM = "/steampulse/test/frontend/revalidate-token"
 _TOKEN = "test-token-abc123"
+_DISTRIBUTION_ID_PARAM = "/steampulse/test/delivery/distribution-id"
+_DISTRIBUTION_ID = "EDFDVBD6EXAMPLE"
 _FRONTEND_BUCKET = "test-frontend-bucket"
 _CACHE_KEY_PREFIX = "cache/test-build/"
 _BUILD_ID = "test-build"
@@ -32,6 +34,7 @@ def _reset_module_state() -> None:
 def _env() -> None:
     os.environ["FRONTEND_BASE_URL"] = _FRONTEND_BASE_URL
     os.environ["REVALIDATE_TOKEN_PARAM"] = _REVALIDATE_TOKEN_PARAM
+    os.environ["DISTRIBUTION_ID_PARAM"] = _DISTRIBUTION_ID_PARAM
     os.environ["FRONTEND_BUCKET"] = _FRONTEND_BUCKET
     os.environ["CACHE_BUCKET_KEY_PREFIX"] = _CACHE_KEY_PREFIX
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
@@ -45,8 +48,34 @@ def _seed_ssm_and_bucket() -> None:
         Type="String",
         Overwrite=True,
     )
+    ssm.put_parameter(
+        Name=_DISTRIBUTION_ID_PARAM,
+        Value=_DISTRIBUTION_ID,
+        Type="String",
+        Overwrite=True,
+    )
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=_FRONTEND_BUCKET)
+
+
+def _stub_cloudfront(handler: Any) -> list[dict]:
+    """Replace handler._cloudfront.create_invalidation with a capturing stub.
+
+    Returns the list that captures kwargs for each call.
+    """
+    captured: list[dict] = []
+
+    def _capture(**kwargs: Any) -> dict:
+        captured.append(kwargs)
+        return {
+            "Invalidation": {
+                "Id": f"I{len(captured)}",
+                "Status": "InProgress",
+            }
+        }
+
+    handler._cloudfront.create_invalidation = _capture  # type: ignore[method-assign]
+    return captured
 
 
 def _cache_key(appid: int, slug: str) -> str:
@@ -67,11 +96,12 @@ def _page_cache_keys_present(appid: int, slug: str) -> bool:
 
 
 def _get_module() -> Any:
-    """Re-seed SSM and reset the lazy http client between tests."""
+    """Re-seed SSM, reset the lazy http client, and stub CloudFront between tests."""
     _seed_ssm_and_bucket()
     import lambda_functions.revalidate_frontend.handler as h
 
     h._http_client = None
+    _stub_cloudfront(h)
     return h
 
 
@@ -329,3 +359,149 @@ def test_unwrapped_sqs_body_also_parses(httpx_mock: HTTPXMock) -> None:
 
     assert result == {"batchItemFailures": []}
     assert len(httpx_mock.get_requests()) == 1
+
+
+@mock_aws
+def test_happy_path_creates_cloudfront_invalidation(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 12345, "slug": _slug(12345), "now": 0},
+    )
+    handler = _get_module()
+    captured = _stub_cloudfront(handler)
+    _put_page_cache(12345, _slug(12345))
+
+    result = handler.handler(_sns_wrapped_event(12345), MockLambdaContext())
+
+    assert result == {"batchItemFailures": []}
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["DistributionId"] == _DISTRIBUTION_ID
+    assert call["InvalidationBatch"]["Paths"] == {
+        "Quantity": 1,
+        "Items": ["/games/12345/*"],
+    }
+    assert call["InvalidationBatch"]["CallerReference"].startswith("revalidate-")
+
+
+@mock_aws
+def test_batched_invalidation_for_multiple_records(httpx_mock: HTTPXMock) -> None:
+    for appid in (10, 20, 30):
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+            json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
+        )
+    handler = _get_module()
+    captured = _stub_cloudfront(handler)
+    for appid in (10, 20, 30):
+        _put_page_cache(appid, _slug(appid))
+
+    result = handler.handler(
+        _multi_record_event([(10, "m-10"), (20, "m-20"), (30, "m-30")]),
+        MockLambdaContext(),
+    )
+
+    assert result == {"batchItemFailures": []}
+    assert len(captured) == 1, "expected ONE invalidation covering all appids"
+    paths = captured[0]["InvalidationBatch"]["Paths"]
+    assert paths["Quantity"] == 3
+    assert paths["Items"] == ["/games/10/*", "/games/20/*", "/games/30/*"]
+
+
+@mock_aws
+def test_cloudfront_failure_marks_all_succeeded_records_as_failed(
+    httpx_mock: HTTPXMock,
+) -> None:
+    for appid in (1, 2):
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+            json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
+        )
+    handler = _get_module()
+
+    def _boom(**_kwargs: Any) -> dict:
+        raise RuntimeError("simulated CloudFront outage")
+
+    handler._cloudfront.create_invalidation = _boom  # type: ignore[method-assign]
+
+    for appid in (1, 2):
+        _put_page_cache(appid, _slug(appid))
+
+    result = handler.handler(
+        _multi_record_event([(1, "ok-1"), (2, "ok-2")]),
+        MockLambdaContext(),
+    )
+
+    assert result == {
+        "batchItemFailures": [
+            {"itemIdentifier": "ok-1"},
+            {"itemIdentifier": "ok-2"},
+        ]
+    }
+
+
+@mock_aws
+def test_per_record_failure_does_not_block_invalidation_for_others(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Records that succeed at /api/revalidate still get invalidated even if a sibling fails."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 100, "slug": _slug(100), "now": 0},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        status_code=500,
+        json={"ok": False},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 300, "slug": _slug(300), "now": 0},
+    )
+    handler = _get_module()
+    captured = _stub_cloudfront(handler)
+    _put_page_cache(100, _slug(100))
+    _put_page_cache(300, _slug(300))
+
+    result = handler.handler(
+        _multi_record_event([(100, "m-100"), (200, "m-200"), (300, "m-300")]),
+        MockLambdaContext(),
+    )
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "m-200"}]}
+    assert len(captured) == 1
+    paths = captured[0]["InvalidationBatch"]["Paths"]
+    assert paths["Items"] == ["/games/100/*", "/games/300/*"]
+
+
+@mock_aws
+def test_module_load_requires_distribution_id_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cold start must fail loudly if DISTRIBUTION_ID_PARAM is unset."""
+    import sys
+
+    _seed_ssm_and_bucket()
+    monkeypatch.delenv("DISTRIBUTION_ID_PARAM", raising=False)
+    sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
+    with pytest.raises(KeyError):
+        import lambda_functions.revalidate_frontend.handler  # noqa: F401
+
+
+@mock_aws
+def test_no_records_skips_cloudfront_call(httpx_mock: HTTPXMock) -> None:
+    """Empty / all-failed batches must NOT issue an invalidation."""
+    handler = _get_module()
+    captured = _stub_cloudfront(handler)
+
+    result = handler.handler({"Records": []}, MockLambdaContext())
+
+    assert result == {"batchItemFailures": []}
+    assert captured == []
+    assert httpx_mock.get_requests() == []

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -495,6 +495,61 @@ def test_module_load_requires_distribution_id_param(
 
 
 @mock_aws
+def test_caller_reference_is_deterministic_across_retries(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Same messageId set must produce the same CallerReference so CloudFront dedupes retries."""
+    for _ in range(2):
+        for appid in (10, 20):
+            httpx_mock.add_response(
+                method="POST",
+                url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+                json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
+            )
+    handler = _get_module()
+    captured = _stub_cloudfront(handler)
+    for appid in (10, 20):
+        _put_page_cache(appid, _slug(appid))
+
+    event = _multi_record_event([(10, "msg-A"), (20, "msg-B")])
+    handler.handler(event, MockLambdaContext())
+    for appid in (10, 20):
+        _put_page_cache(appid, _slug(appid))
+    handler.handler(event, MockLambdaContext())
+
+    assert len(captured) == 2
+    assert captured[0]["InvalidationBatch"]["CallerReference"] == captured[1][
+        "InvalidationBatch"
+    ]["CallerReference"]
+
+
+@mock_aws
+def test_caller_reference_differs_across_distinct_batches(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Distinct messageId sets must produce distinct CallerReferences."""
+    for appid in (10, 20):
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+            json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
+        )
+    handler = _get_module()
+    captured = _stub_cloudfront(handler)
+    for appid in (10, 20):
+        _put_page_cache(appid, _slug(appid))
+
+    handler.handler(_multi_record_event([(10, "msg-A")]), MockLambdaContext())
+    handler.handler(_multi_record_event([(20, "msg-B")]), MockLambdaContext())
+
+    assert len(captured) == 2
+    assert (
+        captured[0]["InvalidationBatch"]["CallerReference"]
+        != captured[1]["InvalidationBatch"]["CallerReference"]
+    )
+
+
+@mock_aws
 def test_no_records_skips_cloudfront_call(httpx_mock: HTTPXMock) -> None:
     """Empty / all-failed batches must NOT issue an invalidation."""
     handler = _get_module()

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -95,14 +95,19 @@ def _page_cache_keys_present(appid: int, slug: str) -> bool:
     return resp.get("KeyCount", 0) > 0
 
 
-def _get_module() -> Any:
-    """Re-seed SSM, reset the lazy http client, and stub CloudFront between tests."""
+def _get_module() -> tuple[Any, list[dict]]:
+    """Re-seed SSM, reset the lazy http client, stub CloudFront, return (handler, captured).
+
+    The returned `captured` list accumulates kwargs of every
+    `create_invalidation` call made through the stubbed client. Tests that
+    don't care about CloudFront can ignore it.
+    """
     _seed_ssm_and_bucket()
     import lambda_functions.revalidate_frontend.handler as h
 
     h._http_client = None
-    _stub_cloudfront(h)
-    return h
+    captured = _stub_cloudfront(h)
+    return h, captured
 
 
 def _slug(appid: int) -> str:
@@ -167,7 +172,7 @@ def test_happy_path_posts_revalidate_and_deletes_s3_page_cache(
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 12345, "slug": _slug(12345), "now": 0},
     )
-    handler = _get_module()
+    handler, _ = _get_module()
     _put_page_cache(12345, _slug(12345))
     assert _page_cache_keys_present(12345, _slug(12345))
 
@@ -194,7 +199,7 @@ def test_s3_delete_failure_returns_batch_item_failure(
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 1, "slug": _slug(1), "now": 0},
     )
-    handler = _get_module()
+    handler, _ = _get_module()
 
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("simulated S3 outage")
@@ -216,7 +221,7 @@ def test_s3_per_key_errors_returns_batch_item_failure(
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 2, "slug": _slug(2), "now": 0},
     )
-    handler = _get_module()
+    handler, _ = _get_module()
 
     def _partial_failure(*_args: object, **_kwargs: object) -> dict:
         return {
@@ -256,7 +261,7 @@ def test_non_2xx_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
         status_code=500,
         json={"ok": False, "error": "boom"},
     )
-    handler = _get_module()
+    handler, _ = _get_module()
     result = handler.handler(_sns_wrapped_event(99, message_id="msg-99"), MockLambdaContext())
 
     assert result == {"batchItemFailures": [{"itemIdentifier": "msg-99"}]}
@@ -264,7 +269,7 @@ def test_non_2xx_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
 
 @mock_aws
 def test_missing_appid_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
-    handler = _get_module()
+    handler, _ = _get_module()
     bad_event = {
         "Records": [
             {
@@ -288,7 +293,7 @@ def test_missing_appid_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None
 
 @mock_aws
 def test_missing_slug_returns_batch_item_failure(httpx_mock: HTTPXMock) -> None:
-    handler = _get_module()
+    handler, _ = _get_module()
     bad_event = {
         "Records": [
             {
@@ -326,7 +331,7 @@ def test_partial_batch_failure_only_reports_failed_record(
         status_code=502,
         json={"ok": False},
     )
-    handler = _get_module()
+    handler, _ = _get_module()
     result = handler.handler(
         _multi_record_event([(1, "ok-msg"), (2, "fail-msg")]),
         MockLambdaContext(),
@@ -343,7 +348,7 @@ def test_unwrapped_sqs_body_also_parses(httpx_mock: HTTPXMock) -> None:
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 7, "slug": _slug(7), "now": 0},
     )
-    handler = _get_module()
+    handler, _ = _get_module()
     direct_event = {
         "Records": [
             {
@@ -368,8 +373,7 @@ def test_happy_path_creates_cloudfront_invalidation(httpx_mock: HTTPXMock) -> No
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 12345, "slug": _slug(12345), "now": 0},
     )
-    handler = _get_module()
-    captured = _stub_cloudfront(handler)
+    handler, captured = _get_module()
     _put_page_cache(12345, _slug(12345))
 
     result = handler.handler(_sns_wrapped_event(12345), MockLambdaContext())
@@ -393,8 +397,7 @@ def test_batched_invalidation_for_multiple_records(httpx_mock: HTTPXMock) -> Non
             url=f"{_FRONTEND_BASE_URL}/api/revalidate",
             json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
         )
-    handler = _get_module()
-    captured = _stub_cloudfront(handler)
+    handler, captured = _get_module()
     for appid in (10, 20, 30):
         _put_page_cache(appid, _slug(appid))
 
@@ -420,7 +423,7 @@ def test_cloudfront_failure_marks_all_succeeded_records_as_failed(
             url=f"{_FRONTEND_BASE_URL}/api/revalidate",
             json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
         )
-    handler = _get_module()
+    handler, _ = _get_module()
 
     def _boom(**_kwargs: Any) -> dict:
         raise RuntimeError("simulated CloudFront outage")
@@ -464,8 +467,7 @@ def test_per_record_failure_does_not_block_invalidation_for_others(
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 300, "slug": _slug(300), "now": 0},
     )
-    handler = _get_module()
-    captured = _stub_cloudfront(handler)
+    handler, captured = _get_module()
     _put_page_cache(100, _slug(100))
     _put_page_cache(300, _slug(300))
 
@@ -506,8 +508,7 @@ def test_caller_reference_is_deterministic_across_retries(
                 url=f"{_FRONTEND_BASE_URL}/api/revalidate",
                 json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
             )
-    handler = _get_module()
-    captured = _stub_cloudfront(handler)
+    handler, captured = _get_module()
     for appid in (10, 20):
         _put_page_cache(appid, _slug(appid))
 
@@ -534,8 +535,7 @@ def test_caller_reference_differs_across_distinct_batches(
             url=f"{_FRONTEND_BASE_URL}/api/revalidate",
             json={"ok": True, "appid": appid, "slug": _slug(appid), "now": 0},
         )
-    handler = _get_module()
-    captured = _stub_cloudfront(handler)
+    handler, captured = _get_module()
     for appid in (10, 20):
         _put_page_cache(appid, _slug(appid))
 
@@ -552,8 +552,7 @@ def test_caller_reference_differs_across_distinct_batches(
 @mock_aws
 def test_no_records_skips_cloudfront_call(httpx_mock: HTTPXMock) -> None:
     """Empty / all-failed batches must NOT issue an invalidation."""
-    handler = _get_module()
-    captured = _stub_cloudfront(handler)
+    handler, captured = _get_module()
 
     result = handler.handler({"Records": []}, MockLambdaContext())
 

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -14,6 +14,9 @@ from tests.conftest import MockLambdaContext
 _FRONTEND_BASE_URL = "https://frontend.example.lambda-url.us-west-2.on.aws"
 _REVALIDATE_TOKEN_PARAM = "/steampulse/test/frontend/revalidate-token"
 _TOKEN = "test-token-abc123"
+_FRONTEND_BUCKET = "test-frontend-bucket"
+_CACHE_KEY_PREFIX = "cache/test-build/"
+_BUILD_ID = "test-build"
 
 
 @pytest.fixture(autouse=True)
@@ -29,10 +32,12 @@ def _reset_module_state() -> None:
 def _env() -> None:
     os.environ["FRONTEND_BASE_URL"] = _FRONTEND_BASE_URL
     os.environ["REVALIDATE_TOKEN_PARAM"] = _REVALIDATE_TOKEN_PARAM
+    os.environ["FRONTEND_BUCKET"] = _FRONTEND_BUCKET
+    os.environ["CACHE_BUCKET_KEY_PREFIX"] = _CACHE_KEY_PREFIX
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
-def _seed_ssm() -> None:
+def _seed_ssm_and_bucket() -> None:
     ssm = boto3.client("ssm", region_name="us-east-1")
     ssm.put_parameter(
         Name=_REVALIDATE_TOKEN_PARAM,
@@ -40,11 +45,30 @@ def _seed_ssm() -> None:
         Type="String",
         Overwrite=True,
     )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=_FRONTEND_BUCKET)
+
+
+def _cache_key(appid: int, slug: str) -> str:
+    return f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/games/{appid}/{slug}"
+
+
+def _put_page_cache(appid: int, slug: str) -> None:
+    s3 = boto3.client("s3", region_name="us-east-1")
+    base = _cache_key(appid, slug)
+    s3.put_object(Bucket=_FRONTEND_BUCKET, Key=f"{base}.cache", Body=b"<html/>")
+    s3.put_object(Bucket=_FRONTEND_BUCKET, Key=f"{base}.cache.meta", Body=b"{}")
+
+
+def _page_cache_keys_present(appid: int, slug: str) -> bool:
+    s3 = boto3.client("s3", region_name="us-east-1")
+    resp = s3.list_objects_v2(Bucket=_FRONTEND_BUCKET, Prefix=_cache_key(appid, slug))
+    return resp.get("KeyCount", 0) > 0
 
 
 def _get_module() -> Any:
     """Re-seed SSM and reset the lazy http client between tests."""
-    _seed_ssm()
+    _seed_ssm_and_bucket()
     import lambda_functions.revalidate_frontend.handler as h
 
     h._http_client = None
@@ -105,13 +129,18 @@ def _multi_record_event(records: list[tuple[int, str]]) -> dict:
 
 
 @mock_aws
-def test_happy_path_posts_revalidate_with_token_appid_slug(httpx_mock: HTTPXMock) -> None:
+def test_happy_path_posts_revalidate_and_deletes_s3_page_cache(
+    httpx_mock: HTTPXMock,
+) -> None:
     httpx_mock.add_response(
         method="POST",
         url=f"{_FRONTEND_BASE_URL}/api/revalidate",
         json={"ok": True, "appid": 12345, "slug": _slug(12345), "now": 0},
     )
     handler = _get_module()
+    _put_page_cache(12345, _slug(12345))
+    assert _page_cache_keys_present(12345, _slug(12345))
+
     result = handler.handler(_sns_wrapped_event(12345), MockLambdaContext())
 
     assert result == {"batchItemFailures": []}
@@ -120,6 +149,73 @@ def test_happy_path_posts_revalidate_with_token_appid_slug(httpx_mock: HTTPXMock
     req = requests[0]
     assert req.headers["x-revalidate-token"] == _TOKEN
     assert json.loads(req.content) == {"appid": 12345, "slug": _slug(12345)}
+    assert not _page_cache_keys_present(12345, _slug(12345)), (
+        "page cache file + .meta should be deleted from S3"
+    )
+
+
+@mock_aws
+def test_s3_delete_failure_returns_batch_item_failure(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 1, "slug": _slug(1), "now": 0},
+    )
+    handler = _get_module()
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("simulated S3 outage")
+
+    monkeypatch.setattr(handler._s3, "delete_objects", _boom)
+    result = handler.handler(_sns_wrapped_event(1, message_id="s3-fail"), MockLambdaContext())
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "s3-fail"}]}
+
+
+@mock_aws
+def test_s3_per_key_errors_returns_batch_item_failure(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delete_objects returns 200 with `Errors` list — must surface as failure."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_FRONTEND_BASE_URL}/api/revalidate",
+        json={"ok": True, "appid": 2, "slug": _slug(2), "now": 0},
+    )
+    handler = _get_module()
+
+    def _partial_failure(*_args: object, **_kwargs: object) -> dict:
+        return {
+            "Deleted": [{"Key": "ok-key"}],
+            "Errors": [{"Key": "bad-key", "Code": "AccessDenied"}],
+        }
+
+    monkeypatch.setattr(handler._s3, "delete_objects", _partial_failure)
+    result = handler.handler(
+        _sns_wrapped_event(2, message_id="s3-partial"), MockLambdaContext()
+    )
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "s3-partial"}]}
+
+
+@mock_aws
+def test_module_load_rejects_malformed_cache_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail fast at cold start if CACHE_BUCKET_KEY_PREFIX is wrong shape."""
+    import sys
+
+    # Seed SSM so the token lookup at module load doesn't fail before reaching
+    # the prefix validation.
+    _seed_ssm_and_bucket()
+    monkeypatch.setenv("CACHE_BUCKET_KEY_PREFIX", "not-cache/foo/")
+    sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
+    with pytest.raises(ValueError, match="must match 'cache/"):
+        import lambda_functions.revalidate_frontend.handler  # noqa: F401
 
 
 @mock_aws


### PR DESCRIPTION
Carefully check this PR!!  It implements prompt at: scripts/prompts/game-report-cloudfront-invalidation.md.

Specific things to check:
- **New IAM permission** on `RevalidateFrontendFn`: `cloudfront:CreateInvalidation` against `arn:aws:cloudfront::{account}:distribution/*`. The `*` is intentional — the distribution ID is resolved at runtime via SSM, not synth time. Confirm this is wired in both staging and prod synth output.
- **New SSM read scope**: the existing `ssm:GetParameter` policy now also covers `/steampulse/{env}/delivery/distribution-id`. Confirm the parameter exists in both envs (it is exported by `DeliveryStack` at `delivery_stack.py:169-174`).
- **New env var**: `DISTRIBUTION_ID_PARAM=/steampulse/{env}/delivery/distribution-id` on `RevalidateFrontendFn`. Verify it shows up in synthesized template for both Staging and Production Compute stacks.
- **Cold-start failure semantics**: handler now requires `DISTRIBUTION_ID_PARAM` env var and a resolvable SSM value at cold start, mirroring the existing token behavior. Missing param → KeyError at module import (covered by `test_module_load_requires_distribution_id_param`).
- **Failure / retry semantics**: if `/api/revalidate` + S3 page-cache delete succeed but `cloudfront:CreateInvalidation` fails, ALL successfully-revalidated records in the batch are added to `batchItemFailures` so SQS retries them (revalidate + S3 delete are idempotent so re-running is safe). Confirm this matches the DLQ alarming expectations.
- **Batching**: one `create_invalidation` per SQS batch covering `/games/{appid}/*` for every successful record. SQS `batch_size=2` × CloudFront's 3,000-paths-per-invalidation cap leaves headroom; this keeps us well under the 15-concurrent-invalidations-per-distribution limit during burst.
- **Cost**: at wedge volume (~200 games × ≤30 re-analyses/month) → ~6,000 paths/month → ~$25/month after the 1,000-path free tier. Acceptable per the prompt.
- **Tests**: 15 cases (9 existing + 6 new) all pass via moto + monkeypatched CloudFront client. No live AWS, no live DB.
- **No DeliveryStack edits, no new dependencies, no `poetry lock` re-run** — confirmed.

Out of scope (per prompt): genre/tag/dev/publisher routes, homepage feeds, runtime-fetching the revalidate token, CloudFront tag-based invalidation. Manual escape hatch `scripts/invalidate-cdn.sh` is preserved untouched.