### PR TITLE
feature/typography-system-upgrade: swap fonts and add fluid type scale

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -20,7 +20,7 @@ export default function AboutPage() {
       <main className="max-w-2xl mx-auto px-6 py-20 space-y-10">
         <header>
           <h1
-            className="font-serif text-4xl md:text-5xl font-bold text-foreground mb-4 leading-tight"
+            className="font-serif text-h1 font-bold text-foreground mb-4 leading-tight"
             style={{ letterSpacing: "-0.03em" }}
           >
             About SteamPulse

--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -31,10 +31,7 @@ export default function AboutPage() {
         </header>
 
         <section className="space-y-4" id="what">
-          <h2
-            className="text-xs uppercase tracking-widest font-mono"
-            style={{ color: "var(--teal)" }}
-          >
+          <h2 className="text-xs uppercase tracking-widest font-mono text-teal">
             What SteamPulse is
           </h2>
           <p className="text-base text-foreground/80 leading-relaxed">
@@ -53,10 +50,7 @@ export default function AboutPage() {
         </section>
 
         <section className="space-y-4" id="methodology">
-          <h2
-            className="text-xs uppercase tracking-widest font-mono"
-            style={{ color: "var(--teal)" }}
-          >
+          <h2 className="text-xs uppercase tracking-widest font-mono text-teal">
             Methodology
           </h2>
           <p className="text-base text-foreground/80 leading-relaxed">
@@ -82,10 +76,7 @@ export default function AboutPage() {
         </section>
 
         <section className="space-y-4" id="author">
-          <h2
-            className="text-xs uppercase tracking-widest font-mono"
-            style={{ color: "var(--teal)" }}
-          >
+          <h2 className="text-xs uppercase tracking-widest font-mono text-teal">
             Who made this
           </h2>
           <p className="text-base text-foreground/80 leading-relaxed">
@@ -100,10 +91,7 @@ export default function AboutPage() {
         </section>
 
         <section className="space-y-4" id="contact">
-          <h2
-            className="text-xs uppercase tracking-widest font-mono"
-            style={{ color: "var(--teal)" }}
-          >
+          <h2 className="text-xs uppercase tracking-widest font-mono text-teal">
             Contact
           </h2>
           <p className="text-base text-foreground/80 leading-relaxed">

--- a/frontend/app/developer/[slug]/page.tsx
+++ b/frontend/app/developer/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function DeveloperPage({ params }: Props) {
         />
 
         <h1
-          className="font-serif text-4xl font-bold mt-6 mb-6"
+          className="font-serif text-h1 font-bold mt-6 mb-6"
           style={{ letterSpacing: "-0.03em" }}
         >
           {name}

--- a/frontend/app/developer/[slug]/page.tsx
+++ b/frontend/app/developer/[slug]/page.tsx
@@ -107,7 +107,7 @@ export default async function DeveloperPage({ params }: Props) {
         {/* Sentiment across catalog */}
         {games.length > 0 && (
           <div className="mb-8 p-4 rounded-xl" style={{ background: "var(--card)", border: "1px solid var(--border)" }}>
-            <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+            <p className="text-eyebrow mb-3">
               Sentiment Across Catalog
             </p>
             <div className="space-y-2">

--- a/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
+++ b/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
@@ -186,7 +186,7 @@ export function GameReportClient({
           <section className="animate-fade-up stagger-1">
             <SectionLabel>The Verdict</SectionLabel>
             <blockquote
-              className="font-serif text-2xl md:text-3xl text-foreground/90 leading-snug mb-8 italic"
+              className="font-serif text-2xl md:text-3xl text-foreground/90 leading-snug mb-8 italic max-w-prose"
               style={{ letterSpacing: "-0.01em" }}
             >
               &ldquo;{report.one_liner ?? "Analysis loading\u2026"}&rdquo;
@@ -200,7 +200,7 @@ export function GameReportClient({
                 metaCrawledAt={metaCrawledAt}
               />
             </div>
-            <div className="flex items-center justify-between text-xs font-mono uppercase tracking-widest text-muted-foreground">
+            <div className="flex items-center justify-between text-eyebrow">
               <span className="inline-flex items-center gap-1.5">
                 <span aria-hidden>✨</span>
                 SteamPulse Analysis
@@ -215,7 +215,7 @@ export function GameReportClient({
                 })()}
               </span>
             </div>
-            <AuthorByline className="mt-3 text-xs font-mono uppercase tracking-widest text-muted-foreground" />
+            <AuthorByline className="mt-3 text-eyebrow" />
           </section>
         )}
 
@@ -276,7 +276,7 @@ export function GameReportClient({
         {report && (
           <section className="animate-fade-up stagger-3">
             <SectionLabel>Design Strengths</SectionLabel>
-            <ul className="space-y-3">
+            <ul className="space-y-3 max-w-prose">
               {(report.design_strengths ?? []).map((item, i) => (
                 <li key={i} className="flex items-start gap-3">
                   <CheckCircle2
@@ -293,7 +293,7 @@ export function GameReportClient({
         {report && (
           <section className="animate-fade-up stagger-4">
             <SectionLabel>Gameplay Friction</SectionLabel>
-            <ul className="space-y-3">
+            <ul className="space-y-3 max-w-prose">
               {(report.gameplay_friction ?? []).map((item, i) => (
                 <li key={i} className="flex items-start gap-3">
                   <AlertCircle
@@ -316,37 +316,32 @@ export function GameReportClient({
                 style={{ background: "var(--card)", border: "1px solid var(--border)" }}
               >
                 <div>
-                  <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-1">
+                  <p className="text-eyebrow mb-1">
                     Ideal Player
                   </p>
-                  <p className="text-base text-foreground/80">
+                  <p className="text-base text-foreground/80 max-w-prose">
                     {report.audience_profile.ideal_player}
                   </p>
                 </div>
                 <div>
-                  <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-1">
+                  <p className="text-eyebrow mb-1">
                     Casual Friendliness
                   </p>
-                  <p className="text-base text-foreground/80">
+                  <p className="text-base text-foreground/80 max-w-prose">
                     {report.audience_profile.casual_friendliness}
                   </p>
                 </div>
               </div>
               <div className="space-y-4">
                 <div>
-                  <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">
+                  <p className="text-eyebrow mb-2">
                     Player Archetypes
                   </p>
                   <div className="flex flex-wrap gap-2">
                     {report.audience_profile.archetypes?.map((a) => (
                       <span
                         key={a}
-                        className="text-sm px-3 py-1.5 rounded-full font-mono"
-                        style={{
-                          background: "rgba(45,185,212,0.08)",
-                          border: "1px solid rgba(45,185,212,0.2)",
-                          color: "var(--teal)",
-                        }}
+                        className="text-sm px-3 py-1.5 rounded-full font-mono bg-teal/8 border border-teal/20 text-teal"
                       >
                         {a}
                       </span>
@@ -354,7 +349,7 @@ export function GameReportClient({
                   </div>
                 </div>
                 <div>
-                  <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">
+                  <p className="text-eyebrow mb-2">
                     Not For
                   </p>
                   <div className="flex flex-wrap gap-2">
@@ -388,7 +383,7 @@ export function GameReportClient({
               <TrendIcon trend={report.sentiment_trend} />
               <div>
                 <p className="text-base font-mono font-medium mb-1">{report.sentiment_trend}</p>
-                <p className="text-base text-muted-foreground leading-relaxed">
+                <p className="text-base text-muted-foreground leading-relaxed max-w-prose">
                   {report.sentiment_trend_note}
                 </p>
               </div>
@@ -399,7 +394,7 @@ export function GameReportClient({
         {report?.genre_context && (
           <section>
             <SectionLabel>Genre Context</SectionLabel>
-            <p className="text-base text-foreground/80 leading-relaxed">
+            <p className="text-base text-foreground/80 leading-relaxed max-w-prose">
               {report.genre_context}
             </p>
           </section>
@@ -415,7 +410,7 @@ export function GameReportClient({
         {report?.player_wishlist && report.player_wishlist.length > 0 && (
           <section>
             <SectionLabel>Player Wishlist</SectionLabel>
-            <ul className="space-y-3">
+            <ul className="space-y-3 max-w-prose">
               {report.player_wishlist.map((item, i) => (
                 <li key={i} className="flex items-start gap-3">
                   <Lightbulb
@@ -432,7 +427,7 @@ export function GameReportClient({
         {report?.churn_triggers && report.churn_triggers.length > 0 && (
           <section>
             <SectionLabel>Churn Triggers</SectionLabel>
-            <ul className="space-y-3">
+            <ul className="space-y-3 max-w-prose">
               {report.churn_triggers.map((item, i) => (
                 <li key={i} className="flex items-start gap-3">
                   <DoorOpen
@@ -460,28 +455,22 @@ export function GameReportClient({
                   }}
                 >
                   <div className="flex items-start gap-3 mb-2">
-                    <span
-                      className="font-mono text-xs px-1.5 py-0.5 rounded mt-0.5 flex-shrink-0"
-                      style={{ background: "rgba(45,185,212,0.1)", color: "var(--teal)" }}
-                    >
+                    <span className="font-mono text-xs px-1.5 py-0.5 rounded mt-0.5 flex-shrink-0 bg-teal/10 text-teal">
                       #{i + 1}
                     </span>
                     <p className="text-base font-medium text-foreground flex items-center gap-2">
-                      <Target
-                        className="w-3.5 h-3.5 flex-shrink-0"
-                        style={{ color: "var(--teal)" }}
-                      />
+                      <Target className="w-3.5 h-3.5 flex-shrink-0 text-teal" />
                       {p.action}
                     </p>
                   </div>
-                  <p className="text-sm text-muted-foreground ml-8 mb-3 leading-relaxed">
+                  <p className="text-sm text-muted-foreground ml-8 mb-3 leading-relaxed max-w-prose">
                     {p.why_it_matters}
                   </p>
                   <div className="flex gap-4 ml-8">
-                    <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                    <span className="text-eyebrow">
                       Freq: <span className="text-foreground/60">{p.frequency}</span>
                     </span>
-                    <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                    <span className="text-eyebrow">
                       Effort: <span className="text-foreground/60">{p.effort}</span>
                     </span>
                   </div>
@@ -520,7 +509,7 @@ export function GameReportClient({
                         {c.comparison_sentiment}
                       </span>
                     </div>
-                    <p className="text-sm text-muted-foreground leading-relaxed">{c.note}</p>
+                    <p className="text-sm text-muted-foreground leading-relaxed max-w-prose">{c.note}</p>
                   </div>
                 </div>
               ))}
@@ -583,12 +572,7 @@ export function GameReportClient({
                 <Link
                   key={tag}
                   href={`/tag/${slugify(tag)}`}
-                  className="text-sm px-3 py-1.5 rounded-full font-mono transition-colors hover:text-foreground"
-                  style={{
-                    background: "rgba(45,185,212,0.08)",
-                    border: "1px solid rgba(45,185,212,0.2)",
-                    color: "var(--teal)",
-                  }}
+                  className="text-sm px-3 py-1.5 rounded-full font-mono transition-colors hover:text-foreground bg-teal/8 border border-teal/20 text-teal"
                 >
                   {tag}
                 </Link>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -170,6 +170,7 @@
 .text-eyebrow {
   font-family: var(--font-mono), monospace;
   font-size: var(--text-eyebrow);
+  line-height: 1rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted-foreground);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -90,13 +90,13 @@
 
   body {
     @apply bg-background text-foreground antialiased;
-    font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family: var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     line-height: var(--leading-normal);
     font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
   }
 
   h1, h2, h3, h4 {
-    font-family: var(--font-fraunces), Georgia, "Times New Roman", serif;
+    font-family: var(--font-serif), Georgia, "Times New Roman", serif;
     letter-spacing: -0.02em;
     line-height: var(--leading-tight);
     font-feature-settings: "ss01" 1, "kern" 1, "liga" 1;
@@ -168,7 +168,7 @@
 
 /* Eyebrow label — uppercase mono caption */
 .text-eyebrow {
-  font-family: var(--font-jetbrains), monospace;
+  font-family: var(--font-mono), monospace;
   font-size: var(--text-eyebrow);
   letter-spacing: 0.1em;
   text-transform: uppercase;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -90,13 +90,13 @@
 
   body {
     @apply bg-background text-foreground antialiased;
-    font-family: var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif);
     line-height: var(--leading-normal);
     font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
   }
 
   h1, h2, h3, h4 {
-    font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+    font-family: var(--font-serif, Georgia, "Times New Roman", serif);
     letter-spacing: -0.02em;
     line-height: var(--leading-tight);
     font-feature-settings: "ss01" 1, "kern" 1, "liga" 1;
@@ -168,7 +168,7 @@
 
 /* Eyebrow label — uppercase mono caption */
 .text-eyebrow {
-  font-family: var(--font-mono), monospace;
+  font-family: var(--font-mono, monospace);
   font-size: var(--text-eyebrow);
   line-height: 1rem;
   letter-spacing: 0.1em;
@@ -176,5 +176,3 @@
   color: var(--muted-foreground);
 }
 
-/* Reading-width cap for long-form prose */
-.prose-readable { max-width: 65ch; }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-syne);
-  --font-serif: var(--font-playfair);
+  --font-sans: var(--font-inter);
+  --font-serif: var(--font-fraunces);
   --font-mono: var(--font-jetbrains);
   --color-ring: var(--ring);
   --color-input: var(--input);
@@ -35,6 +35,18 @@
   --color-gem: var(--gem);
   --color-positive: var(--positive);
   --color-negative: var(--negative);
+  --text-display: clamp(2.5rem, 1.6rem + 4vw, 4.25rem);
+  --text-h1: clamp(2rem, 1.4rem + 2.6vw, 3rem);
+  --text-h2: clamp(1.5rem, 1.2rem + 1.4vw, 2.125rem);
+  --text-h3: clamp(1.25rem, 1.1rem + 0.8vw, 1.5rem);
+  --text-body: 1rem;
+  --text-body-sm: 0.875rem;
+  --text-eyebrow: 0.75rem;
+  --leading-display: 1.05;
+  --leading-tight: 1.15;
+  --leading-snug: 1.3;
+  --leading-normal: 1.55;
+  --leading-relaxed: 1.7;
 }
 
 :root {
@@ -50,7 +62,7 @@
   --secondary:        #1e1e24;
   --secondary-foreground: #ededea;
   --muted:            #1e1e24;
-  --muted-foreground: #7c7c85;
+  --muted-foreground: #9b9ba6;
   --accent:           #1e1e24;
   --accent-foreground: #ededea;
   --destructive:      #ef4444;
@@ -78,13 +90,20 @@
 
   body {
     @apply bg-background text-foreground antialiased;
+    font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: var(--leading-normal);
     font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
   }
 
   h1, h2, h3, h4 {
-    font-family: var(--font-playfair), Georgia, serif;
+    font-family: var(--font-fraunces), Georgia, "Times New Roman", serif;
     letter-spacing: -0.02em;
+    line-height: var(--leading-tight);
+    font-feature-settings: "ss01" 1, "kern" 1, "liga" 1;
   }
+  h1 { font-size: var(--text-h1); }
+  h2 { font-size: var(--text-h2); }
+  h3 { font-size: var(--text-h3); }
 
   /* Subtle noise texture on bg */
   body::before {
@@ -146,3 +165,15 @@
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* Eyebrow label — uppercase mono caption */
+.text-eyebrow {
+  font-family: var(--font-jetbrains), monospace;
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+/* Reading-width cap for long-form prose */
+.prose-readable { max-width: 65ch; }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Playfair_Display, Syne, JetBrains_Mono } from "next/font/google";
+import { Fraunces, Inter, JetBrains_Mono } from "next/font/google";
 import { Navbar } from "@/components/layout/Navbar";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
@@ -30,14 +30,15 @@ const organizationJsonLd = {
   sameAs: ["https://twitter.com/steampulse"],
 };
 
-const playfair = Playfair_Display({
-  variable: "--font-playfair",
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
   subsets: ["latin"],
   display: "swap",
+  axes: ["opsz", "SOFT", "WONK"],
 });
 
-const syne = Syne({
-  variable: "--font-syne",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
   display: "swap",
 });
@@ -87,7 +88,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${playfair.variable} ${syne.variable} ${jetbrains.variable}`}
+      className={`${fraunces.variable} ${inter.variable} ${jetbrains.variable}`}
     >
       <body className="antialiased min-h-screen bg-background text-foreground">
         <script

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -121,7 +121,7 @@ export default async function HomePage() {
   }[] = [
     {
       label: "Most Popular",
-      icon: <TrendingUp className="w-4 h-4" style={{ color: "var(--teal)" }} />,
+      icon: <TrendingUp className="w-4 h-4 text-teal" />,
       games: popularGames,
       seeAll: "/search?sort=review_count",
     },
@@ -139,7 +139,7 @@ export default async function HomePage() {
     },
     {
       label: "New on Steam",
-      icon: <Sparkles className="w-4 h-4" style={{ color: "var(--teal)" }} />,
+      icon: <Sparkles className="w-4 h-4 text-teal" />,
       games: newGames,
       seeAll: "/search?sort=release_date",
     },
@@ -219,7 +219,7 @@ export default async function HomePage() {
           <section>
             <div className="flex items-center justify-between mb-6">
               <div className="flex items-center gap-2">
-                <Clock className="w-4 h-4" style={{ color: "var(--teal)" }} />
+                <Clock className="w-4 h-4 text-teal" />
                 <h2 className="font-serif text-xl font-semibold">Just Analyzed</h2>
               </div>
               <Link

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -160,7 +160,7 @@ export default async function HomePage() {
         />
         <div className="relative max-w-3xl mx-auto px-6 pt-20 pb-12 text-center">
           <h1
-            className="font-serif text-4xl md:text-5xl font-bold text-foreground mb-3 leading-tight"
+            className="font-serif text-h1 font-bold text-foreground mb-3 leading-tight"
             style={{ letterSpacing: "-0.03em" }}
           >
             Steam, decoded

--- a/frontend/app/publisher/[slug]/page.tsx
+++ b/frontend/app/publisher/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function PublisherPage({ params }: Props) {
         />
 
         <h1
-          className="font-serif text-4xl font-bold mt-6 mb-6"
+          className="font-serif text-h1 font-bold mt-6 mb-6"
           style={{ letterSpacing: "-0.03em" }}
         >
           {name}

--- a/frontend/app/publisher/[slug]/page.tsx
+++ b/frontend/app/publisher/[slug]/page.tsx
@@ -107,7 +107,7 @@ export default async function PublisherPage({ params }: Props) {
         {/* Sentiment across catalog */}
         {games.length > 0 && (
           <div className="mb-8 p-4 rounded-xl" style={{ background: "var(--card)", border: "1px solid var(--border)" }}>
-            <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+            <p className="text-eyebrow mb-3">
               Sentiment Across Catalog
             </p>
             <div className="space-y-2">

--- a/frontend/app/reports/ReportsClient.tsx
+++ b/frontend/app/reports/ReportsClient.tsx
@@ -225,7 +225,7 @@ export function ReportsClient() {
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-serif font-bold text-foreground mb-2 flex items-center gap-3">
-            <FileText className="w-7 h-7" style={{ color: "var(--teal)" }} />
+            <FileText className="w-7 h-7 text-teal" />
             Reports
           </h1>
           <p className="text-muted-foreground font-mono text-sm">

--- a/frontend/app/search/SearchClient.tsx
+++ b/frontend/app/search/SearchClient.tsx
@@ -220,7 +220,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
     <div className="space-y-6">
       {/* Search */}
       <div>
-        <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Search</p>
+        <p className="text-eyebrow mb-2">Search</p>
         <form onSubmit={handleSearch}>
           <div className="relative">
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
@@ -238,7 +238,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
       {/* Genres */}
       {!hideGenreFilter && genres.length > 0 && (
         <div>
-          <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Genre</p>
+          <p className="text-eyebrow mb-2">Genre</p>
           <div className="space-y-1 max-h-48 overflow-y-auto">
             {genres.slice(0, 20).map((g) => (
               <label key={g.id} className="flex items-center gap-2 text-sm cursor-pointer hover:text-foreground text-foreground/70">
@@ -260,7 +260,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
       {/* Tags */}
       {!hideTagFilter && tags.length > 0 && (
         <div>
-          <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Tags</p>
+          <p className="text-eyebrow mb-2">Tags</p>
           <div className="space-y-1 max-h-48 overflow-y-auto">
             {tags.slice(0, 20).map((t) => (
               <label key={t.id} className="flex items-center gap-2 text-sm cursor-pointer hover:text-foreground text-foreground/70">
@@ -280,7 +280,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
 
       {/* Min Reviews */}
       <div>
-        <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Min Reviews</p>
+        <p className="text-eyebrow mb-2">Min Reviews</p>
         <div className="space-y-1">
           {REVIEW_PRESETS.map((opt) => (
             <label key={opt.value} className="flex items-center gap-2 text-sm cursor-pointer hover:text-foreground text-foreground/70">
@@ -299,7 +299,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
 
       {/* Sentiment */}
       <div>
-        <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Sentiment</p>
+        <p className="text-eyebrow mb-2">Sentiment</p>
         <div className="space-y-1">
           {SENTIMENT_OPTIONS.map((opt) => (
             <label key={opt.value} className="flex items-center gap-2 text-sm cursor-pointer hover:text-foreground text-foreground/70">
@@ -331,7 +331,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
 
       {/* Price */}
       <div>
-        <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Price</p>
+        <p className="text-eyebrow mb-2">Price</p>
         <div className="space-y-1">
           {PRICE_OPTIONS.map((opt) => (
             <label key={opt.value} className="flex items-center gap-2 text-sm cursor-pointer hover:text-foreground text-foreground/70">
@@ -350,7 +350,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
 
       {/* Year Range */}
       <div>
-        <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">Release Year</p>
+        <p className="text-eyebrow mb-2">Release Year</p>
         <div className="flex gap-2">
           <input
             type="number"
@@ -471,7 +471,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
             ) : (
               <div className="space-y-2">
                 {/* Table header */}
-                <div className="hidden sm:grid grid-cols-12 gap-2 px-4 py-2 text-xs uppercase tracking-widest font-mono text-muted-foreground">
+                <div className="hidden sm:grid grid-cols-12 gap-2 px-4 py-2 text-eyebrow">
                   <div className="col-span-5">Game</div>
                   <div className="col-span-2">Genre</div>
                   <div className="col-span-1 text-right">Reviews</div>
@@ -583,8 +583,7 @@ export function SearchClient({ initialParams, initialFilters, hideGenreFilter, h
             {filterSidebar}
             <button
               onClick={() => setMobileFilters(false)}
-              className="w-full mt-6 py-3 rounded-lg text-base font-mono font-medium"
-              style={{ background: "var(--teal)", color: "#0c0c0f" }}
+              className="w-full mt-6 py-3 rounded-lg text-base font-mono font-medium bg-teal text-background"
             >
               Apply Filters
             </button>

--- a/frontend/app/tag/[slug]/page.tsx
+++ b/frontend/app/tag/[slug]/page.tsx
@@ -75,14 +75,7 @@ export default async function TagPage({ params }: Props) {
 
         <div className="mt-6 mb-6">
           <div className="flex items-center gap-3 mb-2">
-            <span
-              className="text-xs font-mono uppercase tracking-widest px-2 py-0.5 rounded"
-              style={{
-                background: "rgba(45,185,212,0.1)",
-                border: "1px solid rgba(45,185,212,0.2)",
-                color: "var(--teal)",
-              }}
-            >
+            <span className="text-xs font-mono uppercase tracking-widest px-2 py-0.5 rounded bg-teal/10 border border-teal/20 text-teal">
               Tag
             </span>
             <h1
@@ -97,7 +90,7 @@ export default async function TagPage({ params }: Props) {
         {/* Related Tags */}
         {relatedTags.length > 0 && (
           <div className="mb-10">
-            <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">
+            <p className="text-eyebrow mb-2">
               {currentCategory ? `More ${currentCategory} Tags` : "Related Tags"}
             </p>
             <div className="flex flex-wrap gap-2">
@@ -105,12 +98,7 @@ export default async function TagPage({ params }: Props) {
                 <Link
                   key={t.id}
                   href={`/tag/${t.slug}`}
-                  className="text-sm px-3 py-1.5 rounded-full font-mono transition-colors hover:text-foreground"
-                  style={{
-                    background: "rgba(45,185,212,0.06)",
-                    border: "1px solid rgba(45,185,212,0.15)",
-                    color: "var(--teal)",
-                  }}
+                  className="text-sm px-3 py-1.5 rounded-full font-mono transition-colors hover:text-foreground bg-teal/6 border border-teal/15 text-teal"
                 >
                   {t.name}
                 </Link>

--- a/frontend/app/tag/[slug]/page.tsx
+++ b/frontend/app/tag/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default async function TagPage({ params }: Props) {
               Tag
             </span>
             <h1
-              className="font-serif text-4xl font-bold"
+              className="font-serif text-h1 font-bold"
               style={{ letterSpacing: "-0.03em" }}
             >
               {name}

--- a/frontend/components/analytics/DeveloperPortfolio.tsx
+++ b/frontend/components/analytics/DeveloperPortfolio.tsx
@@ -151,7 +151,7 @@ export function DeveloperPortfolio({ data }: DeveloperPortfolioProps) {
         {/* Sentiment trajectory chart */}
         {trajectoryGames.length >= 3 && (
           <div>
-            <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+            <p className="text-eyebrow mb-3">
               Sentiment trajectory
             </p>
             <ResponsiveContainer width="100%" height={200}>

--- a/frontend/components/analytics/GameAnalyticsSection.tsx
+++ b/frontend/components/analytics/GameAnalyticsSection.tsx
@@ -110,7 +110,7 @@ export function GameAnalyticsSection({ appid, gameName }: GameAnalyticsSectionPr
 
   return (
     <div className="space-y-6">
-      <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground">
+      <p className="text-eyebrow">
         Deep Dive Analytics
       </p>
       {hasPlaytime && <PlaytimeSentimentChart data={playtimeSentiment!} />}

--- a/frontend/components/analytics/PlatformGaps.tsx
+++ b/frontend/components/analytics/PlatformGaps.tsx
@@ -86,11 +86,11 @@ export function PlatformGaps({ data }: PlatformGapsProps) {
 
         {underservedPlatform && underservedStats && (
           <div
-            className="mt-4 rounded-lg p-3 text-xs"
-            style={{ background: "var(--card)", border: "1px solid var(--teal)" }}
+            className="mt-4 rounded-lg p-3 text-xs border border-teal"
+            style={{ background: "var(--card)" }}
           >
             <p>
-              <span className="font-medium" style={{ color: "var(--teal)" }}>Opportunity: </span>
+              <span className="font-medium text-teal">Opportunity: </span>
               Only {underservedStats.pct}% of {data.genre} games support{" "}
               {underservedPlatform === "mac" ? "macOS" : underservedPlatform === "linux" ? "Linux" : "Windows"}
               {" "}&mdash; those that do average {underservedStats.avg_steam_pct != null ? `${underservedStats.avg_steam_pct}%` : "\u2014"} positive

--- a/frontend/components/analytics/PublisherPortfolio.tsx
+++ b/frontend/components/analytics/PublisherPortfolio.tsx
@@ -151,7 +151,7 @@ export function PublisherPortfolio({ data }: PublisherPortfolioProps) {
         {/* Sentiment trajectory chart */}
         {trajectoryGames.length >= 3 && (
           <div>
-            <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+            <p className="text-eyebrow mb-3">
               Sentiment trajectory
             </p>
             <ResponsiveContainer width="100%" height={200}>

--- a/frontend/components/game/CompetitiveBenchmark.tsx
+++ b/frontend/components/game/CompetitiveBenchmark.tsx
@@ -19,13 +19,10 @@ function BenchmarkBar({ label, rank, value }: { label: string; rank: number; val
   return (
     <div>
       <div className="flex items-center justify-between mb-1">
-        <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+        <span className="text-eyebrow">
           {label}
         </span>
-        <span
-          className="text-sm font-mono font-medium"
-          style={{ color: "var(--teal)" }}
-        >
+        <span className="text-sm font-mono font-medium text-teal">
           {value}
         </span>
       </div>

--- a/frontend/components/game/GameCard.tsx
+++ b/frontend/components/game/GameCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Gem } from "lucide-react";
 import { EarlyAccessBadge } from "@/components/game/EarlyAccessBadge";
+import { getScoreColor } from "@/lib/styles";
 import type { Game } from "@/lib/types";
 
 interface GameCardProps {
@@ -12,8 +13,7 @@ export function GameCard({ game }: GameCardProps) {
   const href = `/games/${game.appid}/${game.slug}`;
   // Steam's positive_pct is the only sentiment number on cards
   const score = game.positive_pct;
-  const scoreColor =
-    (score ?? 0) >= 75 ? "#22c55e" : (score ?? 0) >= 50 ? "#f59e0b" : "#ef4444";
+  const scoreColor = getScoreColor(score ?? 0);
 
   return (
     <Link

--- a/frontend/components/game/GameHero.tsx
+++ b/frontend/components/game/GameHero.tsx
@@ -67,12 +67,7 @@ export function GameHero({
             <Link
               key={g}
               href={`/genre/${slugify(g)}`}
-              className="text-xs uppercase tracking-widest font-mono px-2 py-0.5 rounded"
-              style={{
-                background: "rgba(45,185,212,0.1)",
-                border: "1px solid rgba(45,185,212,0.2)",
-                color: "var(--teal)",
-              }}
+              className="text-xs uppercase tracking-widest font-mono px-2 py-0.5 rounded bg-teal/10 border border-teal/20 text-teal"
             >
               {g}
             </Link>
@@ -91,8 +86,7 @@ export function GameHero({
                 by{" "}
                 <Link
                   href={`/developer/${developerSlug ?? slugify(developer)}`}
-                  className="hover:underline"
-                  style={{ color: "var(--teal)" }}
+                  className="hover:underline text-teal"
                 >
                   {developer}
                 </Link>
@@ -104,8 +98,7 @@ export function GameHero({
                 published by{" "}
                 <Link
                   href={`/publisher/${publisherSlug ?? slugify(publisher!)}`}
-                  className="hover:underline"
-                  style={{ color: "var(--teal)" }}
+                  className="hover:underline text-teal"
                 >
                   {publisher}
                 </Link>

--- a/frontend/components/game/GameHero.tsx
+++ b/frontend/components/game/GameHero.tsx
@@ -74,7 +74,7 @@ export function GameHero({
           ))}
         </div>
         <h1
-          className="font-serif text-4xl md:text-5xl font-bold text-foreground leading-tight mb-2"
+          className="font-serif text-h1 font-bold text-foreground leading-tight mb-2"
           style={{ letterSpacing: "-0.03em" }}
         >
           {name}

--- a/frontend/components/game/MarketReach.tsx
+++ b/frontend/components/game/MarketReach.tsx
@@ -99,12 +99,7 @@ function MethodPill({ method }: { method: string }) {
   return (
     <Link
       href="/methodology/revenue"
-      className="inline-flex items-center text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded-full hover:underline"
-      style={{
-        background: "rgba(45,185,212,0.1)",
-        color: "var(--teal)",
-        border: "1px solid rgba(45,185,212,0.25)",
-      }}
+      className="inline-flex items-center text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded-full hover:underline bg-teal/10 border border-teal/25 text-teal"
       title="How is this calculated?"
     >
       {method}
@@ -134,7 +129,7 @@ function Stat({
   return (
     <div>
       <div className="flex items-center gap-2 mb-1 flex-wrap">
-        <span className="text-xs uppercase tracking-widest font-mono text-muted-foreground">
+        <span className="text-eyebrow">
           {label}
         </span>
         <ConfidencePill confidence={confidence} />

--- a/frontend/components/game/PlaytimeChart.tsx
+++ b/frontend/components/game/PlaytimeChart.tsx
@@ -22,7 +22,7 @@ export function PlaytimeChart({ buckets, insight }: PlaytimeChartProps) {
   return (
     <div data-testid="playtime-chart">
       <div className="flex items-center gap-2 mb-4">
-        <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground">
+        <p className="text-eyebrow">
           Sentiment by time invested
         </p>
         <span className="text-xs font-mono text-muted-foreground">

--- a/frontend/components/game/PromiseGap.tsx
+++ b/frontend/components/game/PromiseGap.tsx
@@ -127,7 +127,7 @@ export function PromiseGap({ alignment }: PromiseGapProps) {
           >
             {audience.label}
           </span>
-          <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground">
+          <p className="text-eyebrow">
             Audience Match
           </p>
         </div>

--- a/frontend/components/game/RelatedAnalyzedGames.tsx
+++ b/frontend/components/game/RelatedAnalyzedGames.tsx
@@ -35,7 +35,7 @@ export function RelatedAnalyzedGames({ games }: RelatedAnalyzedGamesProps) {
               <div className="min-w-0 flex-1">
                 <p className="font-mono text-sm font-medium truncate">{g.name}</p>
                 {g.positive_pct != null && (
-                  <p className="mt-1 text-xs font-mono" style={{ color: "var(--teal)" }}>
+                  <p className="mt-1 text-xs font-mono text-teal">
                     {g.positive_pct}% positive
                   </p>
                 )}

--- a/frontend/components/game/RequestAnalysis.tsx
+++ b/frontend/components/game/RequestAnalysis.tsx
@@ -65,7 +65,7 @@ export function RequestAnalysis({
         className="rounded-xl p-6"
         style={{ background: "var(--card)", border: "1px solid var(--border)" }}
       >
-        <p className="font-mono text-base" style={{ color: "var(--teal)" }}>
+        <p className="font-mono text-base text-teal">
           You&apos;re on the list.
         </p>
         <p className="mt-2 text-sm text-muted-foreground font-mono">
@@ -94,7 +94,7 @@ export function RequestAnalysis({
         A SteamPulse report covers player sentiment clusters, wishlist signals,
         retention friction points, and competitive context — cited, ~5,000 words.
       </p>
-      <p className="text-xs font-mono uppercase tracking-widest text-muted-foreground mb-4">
+      <p className="text-eyebrow mb-4">
         {socialProof} · usually ready within 2 weeks of hitting ~20 requests
       </p>
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
@@ -117,8 +117,7 @@ export function RequestAnalysis({
           <button
             type="submit"
             disabled={status === "submitting"}
-            className="px-4 py-2 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors disabled:opacity-50"
-            style={{ background: "var(--teal)", color: "#0c0c0f" }}
+            className="px-4 py-2 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors disabled:opacity-50 bg-teal text-background"
           >
             {status === "submitting" ? "Sending..." : "Notify me"}
           </button>
@@ -158,7 +157,7 @@ function CompactCta({
   if (status === "requested" || status === "already_requested") {
     return (
       <div className="flex items-center gap-2 text-xs">
-        <span className="font-mono" style={{ color: "var(--teal)" }}>
+        <span className="font-mono text-teal">
           {status === "requested" ? "Requested!" : "Already requested"}
         </span>
         {requestCount > 0 && (
@@ -188,8 +187,7 @@ function CompactCta({
           <button
             type="submit"
             disabled={status === "submitting"}
-            className="px-3 py-1 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors disabled:opacity-50"
-            style={{ background: "var(--teal)", color: "#0c0c0f" }}
+            className="px-3 py-1 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors disabled:opacity-50 bg-teal text-background"
           >
             {status === "submitting" ? "..." : "Submit"}
           </button>
@@ -210,8 +208,7 @@ function CompactCta({
     <div className="flex items-center gap-3">
       <button
         onClick={() => setShowInput(true)}
-        className="px-3 py-1 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors hover:opacity-90"
-        style={{ background: "var(--teal)", color: "#0c0c0f" }}
+        className="px-3 py-1 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors hover:opacity-90 bg-teal text-background"
       >
         Request Analysis
       </button>

--- a/frontend/components/game/ScoreBar.tsx
+++ b/frontend/components/game/ScoreBar.tsx
@@ -1,15 +1,11 @@
 "use client";
 
+import { getScoreColor } from "@/lib/styles";
+
 interface ScoreBarProps {
   score: number; // 0–100
   label?: string;
   className?: string;
-}
-
-function getScoreColor(score: number): string {
-  if (score >= 75) return "#22c55e";
-  if (score >= 50) return "#f59e0b";
-  return "#ef4444";
 }
 
 function getScoreLabel(score: number): string {

--- a/frontend/components/game/SentimentTimeline.tsx
+++ b/frontend/components/game/SentimentTimeline.tsx
@@ -25,7 +25,7 @@ export function SentimentTimeline({ timeline }: SentimentTimelineProps) {
 
   return (
     <div data-testid="sentiment-timeline">
-      <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+      <p className="text-eyebrow mb-3">
         Sentiment over time
       </p>
       <ResponsiveContainer width="100%" height={140}>

--- a/frontend/components/genre/BenchmarkGrid.tsx
+++ b/frontend/components/genre/BenchmarkGrid.tsx
@@ -23,7 +23,7 @@ export function BenchmarkGrid({ items, totalCount, games, hasReport }: Props) {
 
   return (
     <section className="mb-16" data-testid="benchmark-grid">
-      <h2 className="font-serif text-2xl md:text-3xl font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h2 className="font-serif text-h2 font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
         Benchmark Games
       </h2>
       <p className="text-sm font-mono mb-8" style={{ color: "var(--muted-foreground)" }}>

--- a/frontend/components/genre/BenchmarkGrid.tsx
+++ b/frontend/components/genre/BenchmarkGrid.tsx
@@ -55,10 +55,7 @@ export function BenchmarkGrid({ items, totalCount, games, hasReport }: Props) {
                   {item.why_benchmark}
                 </p>
                 {slug && (
-                  <span
-                    className="mt-4 text-xs font-mono uppercase tracking-widest"
-                    style={{ color: "var(--teal)" }}
-                  >
+                  <span className="mt-4 text-xs font-mono uppercase tracking-widest text-teal">
                     Read the per-game analysis &rarr;
                   </span>
                 )}

--- a/frontend/components/genre/ChurnWall.tsx
+++ b/frontend/components/genre/ChurnWall.tsx
@@ -28,7 +28,7 @@ export function ChurnWall({ insight, interpretation }: Props) {
   const hasHour = insight.typical_dropout_hour > 0;
   return (
     <section className="mb-16" data-testid="churn-wall">
-      <h2 className="font-serif text-2xl md:text-3xl font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h2 className="font-serif text-h2 font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
         The Churn Wall
       </h2>
       <p className="text-sm font-mono mb-8" style={{ color: "var(--muted-foreground)" }}>

--- a/frontend/components/genre/DevPrioritiesTeaser.tsx
+++ b/frontend/components/genre/DevPrioritiesTeaser.tsx
@@ -14,7 +14,7 @@ export function DevPrioritiesTeaser({ items, totalCount, hasReport }: Props) {
 
   return (
     <section className="mb-16" data-testid="dev-priorities">
-      <h2 className="font-serif text-2xl md:text-3xl font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h2 className="font-serif text-h2 font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
         Where Dev Time Pays Off
       </h2>
       <p className="text-sm font-mono mb-8" style={{ color: "var(--muted-foreground)" }}>

--- a/frontend/components/genre/EditorialIntro.tsx
+++ b/frontend/components/genre/EditorialIntro.tsx
@@ -22,7 +22,7 @@ export function EditorialIntro({ insights, shareUrl }: Props) {
   return (
     <header className="mb-12">
       <h1
-        className="font-serif text-4xl md:text-5xl font-bold mb-4"
+        className="font-serif text-h1 font-bold mb-4"
         style={{ letterSpacing: "-0.03em" }}
       >
         What {insights.display_name} Players Want, Hate, and Praise

--- a/frontend/components/genre/FrictionList.tsx
+++ b/frontend/components/genre/FrictionList.tsx
@@ -32,10 +32,7 @@ export function FrictionList({ items, gameCount, games, hasReport }: Props) {
           const src = games[item.source_appid];
           return (
             <li key={idx} className="flex gap-4">
-              <span
-                className="shrink-0 font-mono text-xs pt-1"
-                style={{ color: "var(--teal)" }}
-              >
+              <span className="shrink-0 font-mono text-xs pt-1 text-teal">
                 {String(idx + 1).padStart(2, "0")}
               </span>
               <div className="flex-1 min-w-0">
@@ -49,10 +46,7 @@ export function FrictionList({ items, gameCount, games, hasReport }: Props) {
                   </span>
                 </div>
                 <p className="text-base mb-3 leading-relaxed">{item.description}</p>
-                <blockquote
-                  className="pl-4 border-l-2 text-sm italic"
-                  style={{ borderColor: "var(--teal)", color: "var(--muted-foreground)" }}
-                >
+                <blockquote className="pl-4 border-l-2 border-teal text-sm italic text-muted-foreground">
                   &ldquo;{item.representative_quote}&rdquo;
                   {src && (
                     <>

--- a/frontend/components/genre/FrictionList.tsx
+++ b/frontend/components/genre/FrictionList.tsx
@@ -20,7 +20,7 @@ export function FrictionList({ items, gameCount, games, hasReport }: Props) {
 
   return (
     <section className="mb-16" data-testid="friction-list">
-      <h2 className="font-serif text-2xl md:text-3xl font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h2 className="font-serif text-h2 font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
         Top 5 Friction Points
       </h2>
       <p className="text-sm font-mono mb-8" style={{ color: "var(--muted-foreground)" }}>

--- a/frontend/components/genre/ReportBuyBlock.tsx
+++ b/frontend/components/genre/ReportBuyBlock.tsx
@@ -59,8 +59,8 @@ export function ReportBuyBlock({ report, variant = "main" }: Props) {
   return (
     <aside
       id={variant === "main" ? "buy" : undefined}
-      className={`rounded-xl ${padding}`}
-      style={{ background: "var(--card)", border: "1px solid var(--teal)" }}
+      className={`rounded-xl border border-teal ${padding}`}
+      style={{ background: "var(--card)" }}
       data-testid={`report-buy-block-${variant}`}
       data-state={report.is_pre_order ? "pre-order" : "live"}
     >
@@ -85,12 +85,7 @@ export function ReportBuyBlock({ report, variant = "main" }: Props) {
         type="button"
         onClick={checkout}
         disabled={loading}
-        className="w-full px-4 py-3 rounded-md text-sm font-mono uppercase tracking-widest transition-colors disabled:opacity-60 mb-4"
-        style={{
-          background: "var(--teal)",
-          color: "#0c0c0f",
-          border: "1px solid var(--border)",
-        }}
+        className="w-full px-4 py-3 rounded-md text-sm font-mono uppercase tracking-widest transition-colors disabled:opacity-60 mb-4 bg-teal text-background border border-border"
       >
         {loading ? "…" : `${actionVerb} — ${priceLabel}`}
       </button>

--- a/frontend/components/genre/WishlistList.tsx
+++ b/frontend/components/genre/WishlistList.tsx
@@ -19,7 +19,7 @@ export function WishlistList({ items, gameCount, games, hasReport }: Props) {
 
   return (
     <section className="mb-16" data-testid="wishlist-list">
-      <h2 className="font-serif text-2xl md:text-3xl font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h2 className="font-serif text-h2 font-bold mb-2" style={{ letterSpacing: "-0.02em" }}>
         Top 3 Wishlist Features
       </h2>
       <p className="text-sm font-mono mb-8" style={{ color: "var(--muted-foreground)" }}>

--- a/frontend/components/genre/WishlistList.tsx
+++ b/frontend/components/genre/WishlistList.tsx
@@ -31,7 +31,7 @@ export function WishlistList({ items, gameCount, games, hasReport }: Props) {
           const src = games[item.source_appid];
           return (
             <li key={idx} className="flex gap-4">
-              <span className="shrink-0 font-mono text-xs pt-1" style={{ color: "var(--teal)" }}>
+              <span className="shrink-0 font-mono text-xs pt-1 text-teal">
                 {String(idx + 1).padStart(2, "0")}
               </span>
               <div className="flex-1 min-w-0">
@@ -42,10 +42,7 @@ export function WishlistList({ items, gameCount, games, hasReport }: Props) {
                   </span>
                 </div>
                 <p className="text-base mb-3 leading-relaxed">{item.description}</p>
-                <blockquote
-                  className="pl-4 border-l-2 text-sm italic"
-                  style={{ borderColor: "var(--teal)", color: "var(--muted-foreground)" }}
-                >
+                <blockquote className="pl-4 border-l-2 border-teal text-sm italic text-muted-foreground">
                   &ldquo;{item.representative_quote}&rdquo;
                   {src && (
                     <>

--- a/frontend/components/home/FeaturedReport.tsx
+++ b/frontend/components/home/FeaturedReport.tsx
@@ -63,10 +63,7 @@ export function FeaturedReport({ insights, strip }: Props) {
         border: "1px solid var(--border)",
       }}
     >
-      <p
-        className="text-xs font-mono uppercase tracking-widest mb-4"
-        style={{ color: "var(--teal)" }}
-      >
+      <p className="text-xs font-mono uppercase tracking-widest mb-4 text-teal">
         Featured Report · New
       </p>
 
@@ -83,7 +80,7 @@ export function FeaturedReport({ insights, strip }: Props) {
         patterns, wishlist gaps, benchmark games, and ranked dev priorities.
       </p>
 
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mb-6 text-xs font-mono uppercase tracking-widest text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mb-6 text-eyebrow">
         <span>{insights.input_count} games synthesised</span>
         <span>·</span>
         <span>{positivePct}% positive</span>

--- a/frontend/components/home/FeaturedReport.tsx
+++ b/frontend/components/home/FeaturedReport.tsx
@@ -68,7 +68,7 @@ export function FeaturedReport({ insights, strip }: Props) {
       </p>
 
       <h2
-        className="font-serif text-2xl md:text-3xl font-bold mb-4 leading-tight"
+        className="font-serif text-h2 font-bold mb-4 leading-tight"
         style={{ letterSpacing: "-0.02em" }}
       >
         What {insights.display_name} Players Want, Hate, and Praise

--- a/frontend/components/home/ForDevelopers.tsx
+++ b/frontend/components/home/ForDevelopers.tsx
@@ -9,17 +9,17 @@ interface ValueProp {
 
 const VALUE_PROPS: ValueProp[] = [
   {
-    icon: <Eye className="w-4 h-4" style={{ color: "var(--teal)" }} />,
+    icon: <Eye className="w-4 h-4 text-teal" />,
     title: "Understand your players",
     body: "Review intelligence, sentiment trends, playtime analysis, churn detection.",
   },
   {
-    icon: <Users className="w-4 h-4" style={{ color: "var(--teal)" }} />,
+    icon: <Users className="w-4 h-4 text-teal" />,
     title: "Know your competition",
     body: "Audience overlap shows which games your reviewers actually play.",
   },
   {
-    icon: <LineChart className="w-4 h-4" style={{ color: "var(--teal)" }} />,
+    icon: <LineChart className="w-4 h-4 text-teal" />,
     title: "Read the market",
     body: "Genre trends, pricing analysis, release timing, platform coverage.",
   },
@@ -35,10 +35,7 @@ export function ForDevelopers() {
       }}
     >
       <div className="mb-8">
-        <p
-          className="text-xs font-mono uppercase tracking-widest mb-2"
-          style={{ color: "var(--teal)" }}
-        >
+        <p className="text-xs font-mono uppercase tracking-widest mb-2 text-teal">
           For game developers
         </p>
         <h2 className="font-serif text-2xl md:text-3xl font-semibold text-foreground">
@@ -62,11 +59,7 @@ export function ForDevelopers() {
 
       <Link
         href="/pro"
-        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-mono uppercase tracking-wider transition-all duration-200 hover:scale-[1.02]"
-        style={{
-          background: "var(--teal)",
-          color: "var(--background)",
-        }}
+        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-mono uppercase tracking-wider transition-all duration-200 hover:scale-[1.02] bg-teal text-background"
       >
         Join the Pro waitlist
         <ArrowRight className="w-4 h-4" />

--- a/frontend/components/home/ForDevelopers.tsx
+++ b/frontend/components/home/ForDevelopers.tsx
@@ -38,7 +38,7 @@ export function ForDevelopers() {
         <p className="text-xs font-mono uppercase tracking-widest mb-2 text-teal">
           For game developers
         </p>
-        <h2 className="font-serif text-2xl md:text-3xl font-semibold text-foreground">
+        <h2 className="font-serif text-h2 font-semibold text-foreground">
           Built for the people who make games
         </h2>
       </div>

--- a/frontend/components/home/IntelligenceCards.tsx
+++ b/frontend/components/home/IntelligenceCards.tsx
@@ -67,7 +67,7 @@ export function IntelligenceCards({ snapshot }: IntelligenceCardsProps) {
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <IntelCard
-          icon={<BarChart3 className="w-4 h-4" style={{ color: "var(--teal)" }} />}
+          icon={<BarChart3 className="w-4 h-4 text-teal" />}
           title="Player Sentiment"
           subtitle="Structured by playtime, timeline, and behavior"
           href="/search?sort=review_count"
@@ -80,7 +80,7 @@ export function IntelligenceCards({ snapshot }: IntelligenceCardsProps) {
         </IntelCard>
 
         <IntelCard
-          icon={<Users className="w-4 h-4" style={{ color: "var(--teal)" }} />}
+          icon={<Users className="w-4 h-4 text-teal" />}
           title="Competitive Intelligence"
           subtitle="Real audience overlap from reviewer behavior"
           href="/search?sort=review_count"
@@ -93,7 +93,7 @@ export function IntelligenceCards({ snapshot }: IntelligenceCardsProps) {
         </IntelCard>
 
         <IntelCard
-          icon={<TrendingUp className="w-4 h-4" style={{ color: "var(--teal)" }} />}
+          icon={<TrendingUp className="w-4 h-4 text-teal" />}
           title="Market Intelligence"
           subtitle="Genre trends, pricing, release timing"
           href="/reports"
@@ -106,7 +106,7 @@ export function IntelligenceCards({ snapshot }: IntelligenceCardsProps) {
         </IntelCard>
 
         <IntelCard
-          icon={<FileText className="w-4 h-4" style={{ color: "var(--teal)" }} />}
+          icon={<FileText className="w-4 h-4 text-teal" />}
           title="Deep Review Reports"
           subtitle="Thousands of reviews distilled into structured intelligence"
           href="/reports"

--- a/frontend/components/home/MarketTrendsPreview.tsx
+++ b/frontend/components/home/MarketTrendsPreview.tsx
@@ -121,7 +121,7 @@ export function MarketTrendsPreview() {
             border: "1px solid var(--border)",
           }}
         >
-          <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+          <p className="text-eyebrow mb-3">
             Positively rated releases
           </p>
           {loading ? (
@@ -190,7 +190,7 @@ export function MarketTrendsPreview() {
             border: "1px solid var(--border)",
           }}
         >
-          <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-3">
+          <p className="text-eyebrow mb-3">
             {RELEASE_LABEL[granularity]}
           </p>
           {loading ? (

--- a/frontend/components/home/ProofBar.tsx
+++ b/frontend/components/home/ProofBar.tsx
@@ -17,7 +17,7 @@ export function ProofBar({ totalGames, genreCount }: ProofBarProps) {
           {i > 0 && (
             <span className="text-muted-foreground/40 mr-1.5">·</span>
           )}
-          <span className="font-mono font-medium" style={{ color: "var(--teal)" }}>
+          <span className="font-mono font-medium text-teal">
             {stat.value}
           </span>
           <span className="text-muted-foreground">{stat.label}</span>

--- a/frontend/components/home/TagBrowser.tsx
+++ b/frontend/components/home/TagBrowser.tsx
@@ -98,12 +98,7 @@ export function TagBrowser({ groups }: { groups: TagGroup[] }) {
                     <Link
                       key={tag.id}
                       href={`/tag/${tag.slug}`}
-                      className="text-sm px-3 py-1.5 rounded-full font-mono transition-colors hover:text-foreground"
-                      style={{
-                        background: "rgba(45,185,212,0.06)",
-                        border: "1px solid rgba(45,185,212,0.15)",
-                        color: "var(--teal)",
-                      }}
+                      className="text-sm px-3 py-1.5 rounded-full font-mono transition-colors hover:text-foreground bg-teal/6 border border-teal/15 text-teal"
                     >
                       {tag.name}
                       {tag.game_count != null && (
@@ -116,8 +111,7 @@ export function TagBrowser({ groups }: { groups: TagGroup[] }) {
                   {hasMore && !showAll && (
                     <button
                       onClick={() => toggleShowAll(group.category)}
-                      className="text-sm px-3 py-1.5 font-mono transition-colors"
-                      style={{ color: "var(--teal)" }}
+                      className="text-sm px-3 py-1.5 font-mono transition-colors text-teal"
                     >
                       Show all {group.total_count} &rarr;
                     </button>

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -69,8 +69,7 @@ export function Navbar() {
         {/* Logo */}
         <Link
           href="/"
-          className="font-mono text-sm font-bold tracking-widest uppercase flex-shrink-0"
-          style={{ color: "var(--teal)" }}
+          className="font-mono text-sm font-bold tracking-widest uppercase flex-shrink-0 text-teal"
         >
           SteamPulse
         </Link>
@@ -95,7 +94,7 @@ export function Navbar() {
               >
                 <div className="grid grid-cols-4 gap-4">
                   <div>
-                    <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">
+                    <p className="text-eyebrow mb-2">
                       Genres
                     </p>
                     <div className="space-y-1">
@@ -118,7 +117,7 @@ export function Navbar() {
                   </div>
                   {tagGroups.map((group) => (
                     <div key={group.category}>
-                      <p className="text-xs uppercase tracking-widest font-mono text-muted-foreground mb-2">
+                      <p className="text-eyebrow mb-2">
                         {group.category}
                       </p>
                       <div className="space-y-1">
@@ -140,8 +139,7 @@ export function Navbar() {
                   <Link
                     href="/#browse-by-tag"
                     onClick={() => setBrowseOpen(false)}
-                    className="text-xs font-mono transition-colors"
-                    style={{ color: "var(--teal)" }}
+                    className="text-xs font-mono transition-colors text-teal"
                   >
                     See all tags &rarr;
                   </Link>

--- a/frontend/components/shared/AuthorByline.tsx
+++ b/frontend/components/shared/AuthorByline.tsx
@@ -17,7 +17,7 @@ export function AuthorByline({ className, href }: AuthorBylineProps) {
     <p
       className={
         className ??
-        "text-xs font-mono uppercase tracking-widest text-muted-foreground"
+        "text-eyebrow"
       }
       data-testid="author-byline"
     >

--- a/frontend/lib/styles.ts
+++ b/frontend/lib/styles.ts
@@ -1,0 +1,5 @@
+export function getScoreColor(score: number): string {
+  if (score >= 75) return "#22c55e";
+  if (score >= 50) return "#f59e0b";
+  return "#ef4444";
+}


### PR DESCRIPTION
Carefully check this PR!! It implements prompt at: scripts/prompts/typography-system-upgrade.md.

Specific things to check:

- **Font swap (`frontend/app/layout.tsx`, `frontend/app/globals.css`):** Playfair Display + Syne are gone, replaced by Fraunces (display) + Inter (body) via `next/font/google`. Confirm only the three variable-font CSS variables (`--font-fraunces`, `--font-inter`, `--font-jetbrains`) are wired into `<html>`, no leftover Playfair/Syne references anywhere in the tree.
- **Type scale (`frontend/app/globals.css`):** new `clamp()`-based tokens (`--text-display`, `--text-h1..h3`, `--text-body`, `--text-eyebrow`) and leading scale live in `@theme inline`. Heading rule and body rule both updated to use the new font stacks. Verify visually at 375px and 1440px that h1 scales fluidly without horizontal scroll.
- **`--muted-foreground` bumped from `#7c7c85` → `#9b9ba6`:** spot-check contrast against `--background` (#0c0c0f) and `--card` (#141418). Body text should now meet ≥4.5:1; large text ≥3:1.
- **`getScoreColor` consolidation (`frontend/lib/styles.ts`):** three-bucket logic with hex returns (`#22c55e` ≥75 → `#f59e0b` ≥50 → `#ef4444`). Confirm `ScoreBar.tsx` and `GameCard.tsx` both import from `@/lib/styles` and the threshold semantics match the previous behavior. **Note:** the source prompt suggested a 4-bucket scheme using CSS vars; preserved the existing 3-bucket hex thresholds because that's what was actually in the codebase, per the prompt's own "match existing thresholds" instruction.
- **Inline `var(--teal)` migration:** ~30 static usages migrated to Tailwind utilities (`text-teal`, `bg-teal`, `bg-teal/10 border-teal/20`, etc.). Skipped: SVG/recharts color attrs (`stroke`/`fill`/`stopColor`), dynamic-width inline styles, conditional state-based styles, `getScoreColor()`-driven inline colors. Worth a grep for any missed `style={{ color: "var(--teal)" }}` that should have moved.
- **`max-w-prose` in `GameReportClient.tsx`:** added to 9 prose subsections (Verdict blockquote, Design Strengths/Friction/Wishlist/Churn lists, Audience prose, Sentiment Trend note, Genre Context, why_it_matters, Competitive notes). Genre-side components already had `max-w-prose` in the right places — no changes there. Charts/tables/grids deliberately left uncapped.
- **`.text-eyebrow` utility:** new utility in `globals.css` with `tracking: 0.1em` (matches existing `tracking-widest`). ~20 sites migrated from the canonical `text-xs font-mono uppercase tracking-widest text-muted-foreground` (and the alt-ordered variant) to `text-eyebrow`. Visual output should be byte-identical — flag any site that now looks different.
- **Build:** `npm run build` clean (no type errors). `pytest` 687 passed. **No frontend lint script exists** in `package.json`, so the build's TypeScript check is the only static gate that ran.
- **Out of scope (verify nothing slipped in):** no layout/grid changes, no copy rewrites, no new dependencies, no light-mode work.