### PR TITLE
feature/inline-review-dispatch-from-meta: replace review cron + SNS bridge with inline dispatch from meta ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,4 +44,7 @@ SYSTEM_EVENTS_TOPIC_PARAM_NAME=local
 SPOKE_REGIONS=
 SPOKE_CRAWL_QUEUE_URLS=
 
+# Inline review-crawl dispatch from meta ingest. Operator kill-switch.
+REFRESH_REVIEWS_ENABLED=true
+
 DEV_KEY=  # set to auto-fill unlock key in browser

--- a/.env.production
+++ b/.env.production
@@ -48,3 +48,6 @@ SYSTEM_EVENTS_TOPIC_PARAM_NAME=/steampulse/production/messaging/system-events-to
 # Spoke regions (comma-separated) — primary region must be included
 SPOKE_REGIONS=us-west-2,us-east-1,eu-west-1,eu-central-1,ap-northeast-1,ap-southeast-1
 SPOKE_CRAWL_QUEUE_URLS=
+
+# Inline review-crawl dispatch from meta ingest. Production: enabled.
+REFRESH_REVIEWS_ENABLED=true

--- a/.env.staging
+++ b/.env.staging
@@ -48,3 +48,6 @@ SYSTEM_EVENTS_TOPIC_PARAM_NAME=/steampulse/staging/messaging/system-events-topic
 # Spoke regions (comma-separated) — primary region must be included
 SPOKE_REGIONS=us-west-2,us-east-1
 SPOKE_CRAWL_QUEUE_URLS=
+
+# Inline review-crawl dispatch from meta ingest. Staging: not deployed; field required for CI.
+REFRESH_REVIEWS_ENABLED=false

--- a/ARCHITECTURE.org
+++ b/ARCHITECTURE.org
@@ -195,11 +195,17 @@ All DLQs: max_receive_count=3, retention=14 days.
 | Topic              | Published by  | Subscriptions (filter)                                                          |
 |--------------------+---------------+---------------------------------------------------------------------------------|
 | GameEventsTopic    | CrawlerFn     | MetadataEnrichmentQ: event_type=["game-discovered"]                             |
-|                    |               | ReviewCrawlQ: event_type=["game-metadata-ready"] AND is_eligible=["true"]       |
-|                    |               | ReviewCrawlQ: event_type=["game-released","game-updated"]                       |
 | ContentEventsTopic | SpokeIngestFn | BatchStagingQ: event_type=["reviews-ready"]                                     |
 |                    |               | CacheInvalidationQ: event_type=["report-ready"]                                 |
 | SystemEventsTopic  | CrawlerFn     | (reserved — no active subscriptions)                                            |
+
+ReviewCrawlQ is fed by inline Python dispatch from
+=CrawlService._maybe_dispatch_review_crawl= (called after every meta ingest)
+and by operator drains via =sp.py refresh-reviews=. The previous SNS bridge
+on =game-metadata-ready=/=game-released=/=game-updated= was removed: it was
+ungated and fired aggressively at meta-ingest cadence for every eligible
+game. Inline dispatch applies the same delta gate as =find_due_reviews()=
+and is gated on the =REFRESH_REVIEWS_ENABLED= kill-switch.
 
 ** S3 Buckets
 
@@ -392,8 +398,12 @@ Invariant: All English reviews up to the configured cap (REVIEW_LIMIT) are
 
 *Steps:*
 
-1. =GameEventsTopic= emits =game-metadata-ready= (=is_eligible=true=) → SNS filter
-   routes to =ReviewCrawlQ=. Fresh-start message body: ={appid}= only.
+1. After every meta ingest, =CrawlService._maybe_dispatch_review_crawl= evaluates
+   the same delta gate as =find_due_reviews()= on the just-ingested row. When
+   the gate trips (first fetch, cumulative delta ≥ =REFRESH_REVIEWS_MIN_DELTA=,
+   or 30-day staleness — and =REFRESH_REVIEWS_ENABLED=true=), it sends a
+   =ReviewCrawlMessage{appid, source:"refresh"}= directly to =ReviewCrawlQ=.
+   Operator-triggered drains (=sp.py refresh-reviews=) also write to this queue.
 2. =CrawlerFn= receives SQS record. Unwraps SNS envelope if present.
    Reads =cursor=, =target=, =started_at= from message body (no DB reads):
    - =cursor=: missing/null/"" → normalize to ="*"= (fresh start)
@@ -425,14 +435,14 @@ Invariant: All English reviews up to the configured cap (REVIEW_LIMIT) are
 11. S3 object deleted after all DB/SQS work succeeds (safe to retry on failure — object still present).
 
 #+BEGIN_SRC
-  GameEventsTopic    ReviewCrawlQ       CrawlerFn        SpokeCrawlQ       SpokeCrawlerFn     Steam API     AssetsBucket
-      │                  │            handler.py         (per-region)      spoke_handler.py        │              │
-      │ game-metadata-   │                │                  │                  │                  │              │
-      │ ready {appid}    │                │                  │                  │                  │              │
-      │ is_eligible=true │                │                  │                  │                  │              │
+  CrawlService       ReviewCrawlQ       CrawlerFn        SpokeCrawlQ       SpokeCrawlerFn     Steam API     AssetsBucket
+  (after meta ingest)│            handler.py         (per-region)      spoke_handler.py        │              │
+      │                  │                │                  │                  │                  │              │
+      │ inline dispatch  │                │                  │                  │                  │              │
+      │ {appid, refresh} │                │                  │                  │                  │              │
       │─────────────────>│                │                  │                  │                  │              │
-      │ (SNS filter)     │ SQS receive    │                  │                  │                  │              │
-      │                  │ (b=10)         │                  │                  │                  │              │
+      │ (delta gate +    │ SQS receive    │                  │                  │                  │              │
+      │  kill-switch)    │ (b=10)         │                  │                  │                  │              │
       │                  │───────────────>│                  │                  │                  │              │
       │                  │                │ normalize:       │                  │                  │              │
       │                  │                │ cursor = *       │                  │                  │              │

--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -1086,24 +1086,7 @@ class ComputeStack(cdk.Stack):
             )
         )
 
-        refresh_reviews_rule = events.Rule(
-            self,
-            "RefreshReviewsRule",
-            schedule=events.Schedule.cron(minute="30", hour="*"),
-            description="Hourly tiered review refresh dispatcher (:30)",
-            enabled=config.is_production,
-        )
-        refresh_reviews_rule.add_target(
-            events_targets.LambdaFunction(
-                crawler_fn,
-                event=events.RuleTargetInput.from_object(
-                    {
-                        "action": "refresh_reviews",
-                        "limit": config.REFRESH_REVIEWS_BATCH_LIMIT,
-                    }
-                ),
-            )
-        )
+        # Review refresh dispatches inline from meta ingest; refresh_reviews action handler stays for the operator path.
 
         # Override logical ID to match the pipeline-era stack.
         # Staging only — production was never deployed via CDK Pipelines.

--- a/infra/stacks/messaging_stack.py
+++ b/infra/stacks/messaging_stack.py
@@ -11,7 +11,6 @@ because they hold a CDK reference to the Lambda function.
 import aws_cdk as cdk
 import aws_cdk.aws_events as events
 import aws_cdk.aws_events_targets as events_targets
-import aws_cdk.aws_iam as iam
 import aws_cdk.aws_sns as sns
 import aws_cdk.aws_sns_subscriptions as subs
 import aws_cdk.aws_sqs as sqs
@@ -205,27 +204,7 @@ class MessagingStack(cdk.Stack):
             )
         )
 
-        # review-crawl-queue ← game-events
-        # Single subscription with $or filter: game-metadata-ready (only when
-        # eligible) OR game-released/game-updated (always eligible).
-        # SNS does not allow two subscriptions with the same {Topic, Protocol,
-        # Endpoint} but different filter policies, so we use CfnSubscription
-        # with a raw $or filter policy.
-        review_crawl_sub = sns.CfnSubscription(
-            self,
-            "ReviewCrawlSub",
-            protocol="sqs",
-            topic_arn=self.game_events_topic.topic_arn,
-            endpoint=self.review_crawl_queue.queue_arn,
-            filter_policy={
-                "$or": [
-                    {"event_type": ["game-metadata-ready"], "is_eligible": ["true"]},
-                    {"event_type": ["game-released", "game-updated"]},
-                ],
-            },
-        )
-        # CfnSubscription doesn't auto-grant — allow SNS to deliver to the queue.
-        self.review_crawl_queue.grant_send_messages(iam.ServicePrincipal("sns.amazonaws.com"))
+        # review-crawl-queue is fed by inline Python dispatch from CrawlService and operator drains; no SNS bridge.
 
         # batch-staging-queue ← content-events (reviews-ready only)
         self.content_events_topic.add_subscription(

--- a/scripts/prompts/inline-review-dispatch-from-meta.md
+++ b/scripts/prompts/inline-review-dispatch-from-meta.md
@@ -2,40 +2,62 @@
 
 ## Context
 
-After 0055 shipped delta-gated review refresh, the architecture became:
+After 0055 shipped delta-gated review refresh, the apparent architecture was:
 
 ```
 RefreshMetaRule (hourly @ :00)    → CrawlerFn → meta ingest → writes games.review_count_english
 RefreshReviewsRule (hourly @ :30) → CrawlerFn → find_due_reviews() reads it → delta gate → enqueue
 ```
 
-The two scheduled rules are now logically coupled but architecturally independent. The review dispatcher can only see new deltas *after* meta has refreshed `review_count_english` for that game — so review tier intervals (S=1d/A=3d/B=14d) are bounded above by meta tier intervals (S=2d/A=7d/B=21d) and the faster review windows are unreachable in practice.
+But there's a **third path** the original framing missed. `_publish_crawl_app_events` (`crawl_service.py:486-496`) publishes `GameMetadataReadyEvent` with `is_eligible="true"` after every meta-ingest where `review_count_english >= REVIEW_ELIGIBILITY_THRESHOLD`. An SNS subscription `ReviewCrawlSub` (`messaging_stack.py:214-226`) routes those — plus `game-released` / `game-updated` — directly to `review_crawl_queue`:
 
-Operationally this means:
-- The hourly review dispatcher fires ~720×/month and skips most rows because the upstream signal hasn't moved
-- Two scheduled jobs maintain one logical pipeline
-- 1-hour worst-case lag between meta-write and review-dispatch
-- Review tier-window config is misleading — declares a cadence that can't be achieved
+```python
+filter_policy={
+    "$or": [
+        {"event_type": ["game-metadata-ready"], "is_eligible": ["true"]},
+        {"event_type": ["game-released", "game-updated"]},
+    ],
+}
+```
 
-The cleaner design: dispatch the review crawl inline from meta ingest, at the moment the `review_count_english` delta crosses threshold. The meta cron becomes the only signal source. No second scheduler.
+So **two** producers feed `review_crawl_queue` today: the cron dispatcher and the SNS subscription. Disabling the cron leaves the SNS path firing every hour for every eligible game, ungated by delta. That's where the leftover review traffic is coming from.
+
+This also means review tier intervals (S=1d / A=3d / B=14d) never govern steady-state cadence in practice — the SNS path bypasses them entirely, firing at meta-ingest cadence (S=2d / A=7d / B=21d) for every eligible row.
+
+Operationally:
+- The hourly cron dispatcher (`RefreshReviewsRule`) skips most rows because the upstream signal hasn't moved
+- The SNS path fires aggressively (every meta-ingest of any eligible game) with no delta gate
+- Two scheduled jobs and one event-driven path all maintain the same logical pipeline
+- Review tier-window config is misleading — declares a cadence that's never reached
+
+The cleaner design: dispatch the review crawl inline from meta ingest in Python, gated on the same delta logic `find_due_reviews()` uses. Single source of truth. No second scheduler, no SNS bridge. The meta cron becomes the only steady-state signal source.
 
 ## Goal
 
-Replace the second EventBridge rule with inline dispatch from `_ingest_app_data`, gated on a new `REFRESH_REVIEWS_ENABLED` config kill-switch so the whole review-fetch pipeline can be turned off via a single env var flip without code changes.
+Replace **both** the `RefreshReviewsRule` cron AND the `ReviewCrawlSub` SNS subscription with inline Python dispatch from meta ingest, gated on a new `REFRESH_REVIEWS_ENABLED` config kill-switch so the whole review-fetch pipeline can be turned off via a single env var flip without code changes.
 
 **Estimated impact:**
-- Eliminates ~720 dispatcher invocations/month (negligible $ but cleaner)
-- Removes the 1-hour meta→review lag — review crawl enqueues at the exact moment meta observes the delta
+- Eliminates ~720 cron dispatcher invocations/month (negligible $ but cleaner)
+- Eliminates the ungated SNS path (the one that's been quietly fetching reviews on every eligible meta-ingest)
+- Removes the 1-hour meta→review lag from the cron path — review crawl enqueues at the exact moment meta observes the delta
+- Adds delta gating to what was previously the SNS-driven always-on path
 - Removes misleading review tier-window config from the dispatch path
 - Provides operator kill-switch for cost containment: flip `REFRESH_REVIEWS_ENABLED=false` on the `CrawlerFn` Lambda env, no review fetches enqueue at all
 
 The architectural cleanup is the primary motivation; the kill-switch closes the cost-blast-radius concern.
 
+### Why drop the `game-released` and `game-updated` triggers
+
+- **`GameUpdatedEvent`**: defined in `events.py:82` but **never published** from any active code path. It's dead routing.
+- **`GameReleasedEvent`**: published from `crawl_service.py:507` when `coming_soon` flips True→False. Redundant with delta-driven first-fetch logic — a freshly-released game's first review fetch will fire the moment meta-ingest observes `review_count_english >= REFRESH_TIER_B_REVIEW_COUNT` (since `review_crawled_at IS NULL` ⇒ `is_first_fetch=True` ⇒ dispatch). The only edge case is a released game that never accumulates ≥ tier-B reviews, but that's identical to today's SNS-path behavior (which gates on the same `REVIEW_ELIGIBILITY_THRESHOLD`), so no regression.
+
+The `GameReleasedEvent` publish site stays intact — it's still useful as a domain signal for any other consumers; we're only removing the review-crawl routing of it.
+
 ## Approach
 
 ### 1. Add `REFRESH_REVIEWS_ENABLED` to config — `src/library-layer/library_layer/config.py` `[code]`
 
-New field, no default per `feedback_no_field_defaults`:
+New required field, no default per `feedback_no_field_defaults`:
 
 ```python
 REFRESH_REVIEWS_ENABLED: bool  # gate inline review dispatch from meta ingest
@@ -50,42 +72,48 @@ When `False`: meta ingest never enqueues review crawls. The operator-triggered p
 - `.env.staging`: `REFRESH_REVIEWS_ENABLED=false` (no staging deploy, but field is required)
 - `.env.production`: `REFRESH_REVIEWS_ENABLED=true`
 
-Note: per `feedback_no_staging_schedules`, prod is the only deployed env. `.env.staging` exists only to satisfy config validation in CI.
+Per `feedback_no_staging_schedules`, prod is the only deployed env. `.env.staging` exists only to satisfy config validation in CI.
 
-### 3. Add a single-appid enqueue method — `src/library-layer/library_layer/services/catalog_service.py` `[code]`
+### 3. Extend `find_event_snapshot` — `src/library-layer/library_layer/repositories/game_repo.py:144-153` `[code]`
 
-Current `enqueue_refresh_reviews(limit: int)` walks `find_due_reviews()`. Add a sibling method that enqueues an explicit list — used by the inline dispatch path:
+Currently selects only `coming_soon, price_usd, review_count` from `games`. The inline dispatch helper needs `review_count_english` (already on `games`) plus `review_crawled_at` and `review_count_at_last_fetch` (both on `app_catalog`, not `games`). Extend with a `LEFT JOIN app_catalog`:
 
 ```python
-def enqueue_review_crawl_for_appids(self, appids: list[int]) -> int:
-    """Enqueue review crawl for explicit appids. Used by inline dispatch from
-    meta ingest; bypasses tier-window/delta SQL gate (caller has already
-    decided). Returns count enqueued."""
-    if not appids:
-        return 0
-    messages = [
-        ReviewCrawlMessage(appid=a, source="refresh").model_dump()
-        for a in appids
-    ]
-    send_sqs_batch(self._sqs, self._review_crawl_queue_url, messages)
-    logger.info(
-        "inline_review_dispatch enqueued",
-        extra={"appids": appids, "count": len(appids)},
+def find_event_snapshot(self, appid: int) -> dict | None:
+    row = self._fetchone(
+        "SELECT g.coming_soon, g.price_usd, g.review_count, g.review_count_english, "
+        "       c.review_crawled_at, c.review_count_at_last_fetch "
+        "FROM games g LEFT JOIN app_catalog c USING (appid) "
+        "WHERE g.appid = %s",
+        (appid,),
     )
-    return len(appids)
+    return dict(row) if row else None
 ```
 
-Distinct method (not an overload on `enqueue_refresh_reviews`) so the dispatcher-vs-inline call sites stay clearly separable in logs and tests.
+The wider snapshot is still much narrower than `find_by_appid`'s TOAST-heavy projection, so the perf rationale in the docstring stays valid. The `LEFT JOIN` (vs `INNER`) preserves the existing semantics that a row in `games` without an `app_catalog` row still returns a snapshot — `review_crawled_at` and `review_count_at_last_fetch` will simply come back as `None`.
 
-### 4. Inline dispatch from meta ingest — `src/library-layer/library_layer/services/crawl_service.py` `[code]`
+### 4. Inline SQS dispatch in `CrawlService` (no new `CatalogService` method) `[code]`
 
-In `_ingest_app_data` (line 297), after the games-row upsert returns the new row, observe the delta and dispatch:
+`CrawlService` already has `self._sqs` and `self._review_queue_url` from its existing constructor — no cross-service dependency needed. Putting the dispatch on `CatalogService` would require injecting `CatalogService` into `CrawlService` and updating three construction sites (`crawler/handler.py`, `crawler/ingest_handler.py`, and `scripts/sp.py` — the last of which never builds a `CatalogService`). Simpler to keep the inline dispatch local to `CrawlService`:
 
 ```python
-# Inline review-crawl dispatch (replaces RefreshReviewsRule scheduler).
-# Gated on REFRESH_REVIEWS_ENABLED kill-switch.
-if self._config.REFRESH_REVIEWS_ENABLED:
-    self._maybe_dispatch_review_crawl(appid, existing, game_data)
+# Inside _maybe_dispatch_review_crawl, when the gate decides "yes":
+msg = ReviewCrawlMessage(appid=appid, source="refresh").model_dump()
+send_sqs_batch(self._sqs, self._review_queue_url, [msg])
+logger.info("inline_review_dispatch enqueued", extra={"appid": appid})
+```
+
+The dispatcher-vs-inline distinction is preserved by the log key (`inline_review_dispatch` vs `refresh_reviews`). `CatalogService.enqueue_refresh_reviews(limit=)` stays exactly as-is for the operator drain path.
+
+### 5. Inline dispatch from meta ingest — `src/library-layer/library_layer/services/crawl_service.py` `[code]`
+
+`_publish_crawl_app_events` is called from **two** places — `crawl_app` (line 172, direct crawl path) and `ingest_spoke_metadata` (line 269, spoke result ingest path). Both produce `GameMetadataReadyEvent` and so both used to fan out to review-crawl via the SNS subscription. The inline helper must be wired at both call sites so we don't lose dispatch coverage.
+
+Right after `_publish_crawl_app_events`:
+
+```python
+self._publish_crawl_app_events(appid, game_data, existing)
+self._maybe_dispatch_review_crawl(appid, existing, game_data)
 ```
 
 New helper on `CrawlService`:
@@ -101,6 +129,9 @@ def _maybe_dispatch_review_crawl(
     enqueue a review crawl. Mirrors find_due_reviews() gate logic but in
     Python on the just-ingested row, so dispatch happens at the moment the
     signal changes — no second scheduler, no SQL re-poll."""
+    if not self._config.REFRESH_REVIEWS_ENABLED:
+        return
+
     new_rce = game_data.get("review_count_english", 0) or 0
 
     # Tier eligibility (matches find_due_reviews WHERE clause)
@@ -109,34 +140,50 @@ def _maybe_dispatch_review_crawl(
     if game_data.get("coming_soon"):
         return  # no reviews to refresh until launch
 
-    old_rce = (existing.get("review_count_english") if existing else 0) or 0
-    delta = new_rce - old_rce
-
-    # Mirror find_due_reviews() final WHERE: NULL OR delta>=min OR 30d-stale
     review_crawled_at = existing.get("review_crawled_at") if existing else None
     is_first_fetch = review_crawled_at is None
-    delta_met = delta >= self._config.REFRESH_REVIEWS_MIN_DELTA
-    is_stale = (
-        review_crawled_at is not None
-        and (datetime.now(tz=timezone.utc) - review_crawled_at).days >= 30
-    )
+    if is_first_fetch:
+        self._dispatch_review_crawl(appid)
+        return
 
-    if is_first_fetch or delta_met or is_stale:
-        self._catalog_service.enqueue_review_crawl_for_appids([appid])
+    last_fetch_rce = (existing.get("review_count_at_last_fetch") or 0)
+    delta = new_rce - last_fetch_rce
+    delta_met = delta >= self._config.REFRESH_REVIEWS_MIN_DELTA
+    is_stale = (datetime.now(tz=timezone.utc) - review_crawled_at).days >= 30
+
+    if delta_met or is_stale:
+        self._dispatch_review_crawl(appid)
+
+def _dispatch_review_crawl(self, appid: int) -> None:
+    msg = ReviewCrawlMessage(appid=appid, source="refresh").model_dump()
+    send_sqs_batch(self._sqs, self._review_queue_url, [msg])
+    logger.info("inline_review_dispatch enqueued", extra={"appid": appid})
 ```
 
 Notes:
-- Reuses `existing` (already loaded by `find_event_snapshot` upstream — no extra DB call)
-- `find_event_snapshot` currently returns `dict | None`; verify it includes `review_count_english`, `review_crawled_at`, `coming_soon`. If not, extend the SELECT in `game_repo.py:144` (this is the only repo change).
-- The Python condition mirrors `find_due_reviews()`'s final WHERE clause exactly — same semantics, just evaluated inline instead of via SQL.
+- Reuses `existing` already loaded by `find_event_snapshot` — no extra DB call once #3 lands
+- The delta is computed against `review_count_at_last_fetch` (the value at last review crawl, on `app_catalog`), **not** the pre-upsert `games.review_count_english`. This matches `find_due_reviews()` semantics — cumulative growth since last fetch, not per-ingest growth. Per-ingest delta would essentially never cross `REFRESH_REVIEWS_MIN_DELTA=1000`, leaving the gate effectively closed.
+- Wired at both `crawl_app:172` and `ingest_spoke_metadata:269`
 
-### 5. Delete `RefreshReviewsRule` — `infra/stacks/compute_stack.py` `[code]`
+### 6. Delete `RefreshReviewsRule` — `infra/stacks/compute_stack.py:1089-1108` `[code]`
 
-Lines ~1089–1108: remove `refresh_reviews_rule` and its `add_target` call entirely. Remove any matching assertion in `tests/infra/test_compute_stack.py`.
+Remove `refresh_reviews_rule` and its `add_target` call entirely. Drop matching assertion in `tests/infra/test_compute_stack.py`.
 
 The `refresh_reviews` action handler in the crawler Lambda stays intact — `sp.py refresh-reviews` operator path still routes through it.
 
-### 6. Tests — `tests/services/test_crawl_service.py` `[code]`
+### 7. Delete `ReviewCrawlSub` — `infra/stacks/messaging_stack.py:214-228` `[code]`
+
+Remove the `CfnSubscription` (the SNS→SQS bridge for review crawls) AND the `self.review_crawl_queue.grant_send_messages(iam.ServicePrincipal("sns.amazonaws.com"))` line that supports it.
+
+The `review_crawl_queue` itself stays — it's still fed by inline Python dispatch (CrawlerFn already has `grant_send_messages(crawler_role)`) and operator-triggered drains.
+
+`_publish_crawl_app_events` continues to publish `GameMetadataReadyEvent`, `GameReleasedEvent`, `GamePriceChangedEvent` to `GameEventsTopic`. We're only removing the review-crawl routing of those events; the topic and any other subscribers keep working.
+
+`GameUpdatedEvent`: leave the model definition for now (low cost, could be revived). Confirmed not published from any active code path.
+
+Drop matching filter assertions in `tests/infra/test_messaging_stack.py:99-100` (the `game-released` / `game-updated` checks).
+
+### 8. Tests — `tests/services/test_crawl_service.py` `[code]`
 
 Add cases for `_maybe_dispatch_review_crawl`:
 - `REFRESH_REVIEWS_ENABLED=False` → never dispatches (test the kill-switch)
@@ -153,30 +200,37 @@ Update `tests/test_config.py` — no default to assert; assert env var is requir
 
 Per `feedback_test_db.md`, repository tests must hit `steampulse_test`.
 
-### 7. Update tiered-refresh docs — `tiered-refresh-schedule.org` `[doc]`
+### 9. Update tiered-refresh docs — `tiered-refresh-schedule.org` and `ARCHITECTURE.org` `[doc]`
 
-Update the doc to reflect the new architecture:
+`tiered-refresh-schedule.org`:
 - Remove the `RefreshReviewsRule` row from the cron table
 - Note that review dispatch is inline from meta ingest, gated on `REFRESH_REVIEWS_ENABLED`
 - Review tier intervals (`REFRESH_REVIEWS_TIER_*_DAYS`) only affect the operator-triggered `sp.py refresh-reviews` path now; not the steady-state pipeline
+
+`ARCHITECTURE.org`:
+- Update line 199 (review-crawl-queue subscription description) — remove the `["game-released","game-updated"]` filter mention
+- Update meta-ingest sequence diagram to show inline dispatch instead of SNS routing
 
 ## Critical files
 
 - `src/library-layer/library_layer/config.py` — add `REFRESH_REVIEWS_ENABLED`
 - `.env`, `.env.example`, `.env.staging`, `.env.production` — wire the new field
+- `src/library-layer/library_layer/repositories/game_repo.py:144-153` — extend `find_event_snapshot` SELECT
 - `src/library-layer/library_layer/services/catalog_service.py` — add `enqueue_review_crawl_for_appids`
-- `src/library-layer/library_layer/services/crawl_service.py:297` — inline dispatch in `_ingest_app_data`, plus `_maybe_dispatch_review_crawl` helper
-- `src/library-layer/library_layer/repositories/game_repo.py:144` — verify `find_event_snapshot` returns the fields the helper needs (extend SELECT if not)
+- `src/library-layer/library_layer/services/crawl_service.py:172,269` — call `_maybe_dispatch_review_crawl` from both `crawl_app` and `ingest_spoke_metadata`; add the helper
 - `infra/stacks/compute_stack.py:1089-1108` — delete `RefreshReviewsRule`
+- `infra/stacks/messaging_stack.py:214-228` — delete `ReviewCrawlSub` and the SNS service-principal grant
 - `tests/services/test_crawl_service.py` — gate behavior tests
-- `tests/infra/test_compute_stack.py` — drop matching assertion
+- `tests/infra/test_compute_stack.py` — drop `RefreshReviewsRule` assertion
+- `tests/infra/test_messaging_stack.py:99-100` — drop `game-released`/`game-updated` filter assertions
 - `tests/conftest.py`, `tests/test_config.py` — env wiring
-- `tiered-refresh-schedule.org` — doc update
+- `tiered-refresh-schedule.org`, `ARCHITECTURE.org` — doc update
 
 ## Out of scope
 
 - **Review tier-window config retirement** — `REFRESH_REVIEWS_TIER_S/A/B_DAYS` and the dispatcher-path `enqueue_refresh_reviews(limit=)` stay intact. Operator-triggered drain (`sp.py refresh-reviews`) still uses them. Revisit only if the operator path also gets eliminated.
 - **Touching the metadata cron** — `RefreshMetaRule` cadence and `find_due_meta()` semantics unchanged.
+- **Deleting `GameUpdatedEvent` model or the `GameReleasedEvent` publish site** — those still exist / publish to `GameEventsTopic`; we're only removing the review-crawl routing of them.
 - **Backfill** — no migration needed. The 0055 migration already initialized `review_count_at_last_fetch` to current `review_count_english` for previously-fetched rows. Cold deploy: first meta pass per game observes delta=0 → no dispatch unless real growth has accrued.
 - **Auto-redeploy on env-var flip** — operator flips `REFRESH_REVIEWS_ENABLED` via `aws lambda update-function-configuration` (or a `cdk deploy` with edited env file). Lambda re-inits within ~1 minute.
 
@@ -191,7 +245,11 @@ poetry run pytest tests/  # full suite, --no-mock policy applies (feedback_test_
 
 ### Pre-deploy sanity
 
-Re-confirm `find_event_snapshot` returns `review_count_english`, `review_crawled_at`, and `coming_soon`. If not, extend before deploying or `_maybe_dispatch_review_crawl` will silently skip dispatches.
+`cdk diff` should show exactly two infra changes:
+1. `RefreshReviewsRule` removed
+2. `ReviewCrawlSub` removed (and its SNS service-principal grant)
+
+If anything else changed, investigate before deploying.
 
 ### Post-deploy (24–48h after enabling, with `REFRESH_REVIEWS_ENABLED=true`)
 
@@ -200,15 +258,21 @@ Re-confirm `find_event_snapshot` returns `review_count_english`, `review_crawled
 aws events list-rules --name-prefix Refresh --region us-west-2 --output table
 # Expect: only RefreshMetaRule (and CatalogRefresh)
 
-# 2. Confirm review-crawl queue is being fed by inline dispatch (not cron)
+# 2. Confirm ReviewCrawlSub is gone
+aws sns list-subscriptions-by-topic \
+  --topic-arn $(aws ssm get-parameter --name /steampulse/production/messaging/game-events-topic-arn --query Parameter.Value --output text --region us-west-2) \
+  --region us-west-2 --output table
+# Expect: no subscription pointing at review_crawl_queue
+
+# 3. Confirm review-crawl queue is being fed by inline dispatch
 aws cloudwatch get-metric-statistics --namespace AWS/SQS --metric-name NumberOfMessagesSent \
   --dimensions Name=QueueName,Value=steampulse-review-crawl-production \
   --start-time $(date -v-2d -u +%Y-%m-%dT%H:%M:%SZ) \
   --end-time $(date -u +%Y-%m-%dT%H:%M:%SZ) \
   --period 3600 --statistics Sum --region us-west-2
-# Pattern should track meta-ingest hour-by-hour, not the prior :30-spike pattern
+# Pattern should track meta-ingest hour, with delta gating ⇒ much lower volume than the prior ungated SNS path
 
-# 3. Grep dispatcher logs for the new event
+# 4. Grep CrawlerFn logs for the new event
 poetry run python scripts/logs.py crawler --env production --grep inline_review_dispatch
 ```
 
@@ -222,12 +286,9 @@ aws lambda update-function-configuration \
   --environment "Variables={...,REFRESH_REVIEWS_ENABLED=false}" \
   --region us-west-2
 
-# Wait one meta cycle (1 hour). Check queue:
-aws sqs get-queue-attributes \
-  --queue-url $(aws sqs get-queue-url --queue-name steampulse-review-crawl-production --region us-west-2 --query QueueUrl --output text) \
-  --attribute-names ApproximateNumberOfMessagesSent \
-  --region us-west-2
-# NumberOfMessagesSent over the last hour should be ~0
+# Wait one meta cycle (1 hour). Confirm no new inline_review_dispatch log lines:
+poetry run python scripts/logs.py crawler --env production --grep inline_review_dispatch --since 1h
+# Expect: zero matches
 ```
 
 Then flip it back on (or `cdk deploy` to restore from `.env.production`).

--- a/src/library-layer/library_layer/config.py
+++ b/src/library-layer/library_layer/config.py
@@ -168,6 +168,12 @@ class SteamPulseConfig(BaseSettings):
     # adds a minimum-change requirement to skip near-no-op refetches.
     REFRESH_REVIEWS_MIN_DELTA: int = 1000
 
+    # Inline review-crawl dispatch from meta ingest. Operator kill-switch — when
+    # False, _maybe_dispatch_review_crawl returns early and no review fetches enqueue
+    # from the steady-state pipeline. Operator path (sp.py refresh-reviews →
+    # CatalogService.enqueue_refresh_reviews) is intentionally NOT gated.
+    REFRESH_REVIEWS_ENABLED: bool
+
     @model_validator(mode="after")
     def _validate_refresh_tier_config(self) -> Self:
         """Guard against env overrides that would break the dispatcher SQL.

--- a/src/library-layer/library_layer/repositories/game_repo.py
+++ b/src/library-layer/library_layer/repositories/game_repo.py
@@ -143,11 +143,20 @@ class GameRepository(BaseRepository):
 
     def find_event_snapshot(self, appid: int) -> dict | None:
         """Minimal pre-upsert snapshot for event detection (coming_soon flip, price change,
-        review milestone crossings). Avoids the wide TOAST-heavy row that find_by_appid
-        returns, which is the right read for API handlers but wasteful on hot refresh paths.
+        review milestone crossings) plus inline review-crawl dispatch gating. Avoids the
+        wide TOAST-heavy row that find_by_appid returns, which is the right read for API
+        handlers but wasteful on hot refresh paths.
+
+        Includes app_catalog.review_crawled_at and review_count_at_last_fetch via LEFT
+        JOIN so _maybe_dispatch_review_crawl can mirror find_due_reviews()'s WHERE clause
+        in Python without a second roundtrip. The LEFT JOIN preserves snapshot semantics
+        for games that lack an app_catalog row — both columns simply come back as None.
         """
         row = self._fetchone(
-            "SELECT coming_soon, price_usd, review_count FROM games WHERE appid = %s",
+            "SELECT g.coming_soon, g.price_usd, g.review_count, g.review_count_english, "
+            "       c.review_crawled_at, c.review_count_at_last_fetch "
+            "FROM games g LEFT JOIN app_catalog c USING (appid) "
+            "WHERE g.appid = %s",
             (appid,),
         )
         return dict(row) if row else None
@@ -458,11 +467,7 @@ class GameRepository(BaseRepository):
             conditions.append("g.name ILIKE %s")
             params.append(f"%{search_term}%")
             # Boost exact and prefix matches so "Minato" ranks above "Terminator"
-            order = (
-                f"(LOWER(g.name) = LOWER(%s))::int DESC, "
-                f"(g.name ILIKE %s)::int DESC, "
-                f"{order}"
-            )
+            order = f"(LOWER(g.name) = LOWER(%s))::int DESC, (g.name ILIKE %s)::int DESC, {order}"
             params.append(search_term)
             params.append(f"{search_term}%")
 
@@ -530,9 +535,7 @@ class GameRepository(BaseRepository):
             result.append(d)
         return {"total": None, "games": result}
 
-    def find_basics_by_appids(
-        self, appids: list[int]
-    ) -> list[dict[str, object]]:
+    def find_basics_by_appids(self, appids: list[int]) -> list[dict[str, object]]:
         """Return [{appid, name, slug, header_image, positive_pct, review_count}, ...]
         for the given appids.
 
@@ -562,9 +565,7 @@ class GameRepository(BaseRepository):
         by_appid = {int(r["appid"]): dict(r) for r in rows}
         return [by_appid[a] for a in appids if a in by_appid]
 
-    def find_review_stats_for_appids(
-        self, appids: list[int]
-    ) -> list[dict[str, object]]:
+    def find_review_stats_for_appids(self, appids: list[int]) -> list[dict[str, object]]:
         """Return [{appid, positive_pct, review_count}, ...] for the given appids.
 
         Used by the Phase-4 synthesizer to compute aggregate descriptors

--- a/src/library-layer/library_layer/services/crawl_service.py
+++ b/src/library-layer/library_layer/services/crawl_service.py
@@ -3,7 +3,7 @@
 import gzip
 import json
 import uuid
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 from aws_lambda_powertools import Logger
@@ -12,6 +12,7 @@ from library_layer.events import (
     GameMetadataReadyEvent,
     GamePriceChangedEvent,
     GameReleasedEvent,
+    ReviewCrawlMessage,
     ReviewMilestoneEvent,
     ReviewsReadyEvent,
 )
@@ -22,6 +23,7 @@ from library_layer.repositories.tag_repo import TagRepository
 from library_layer.steam_source import DirectSteamSource, SteamAPIError
 from library_layer.utils.events import EventPublishError, publish_event
 from library_layer.utils.slugify import slugify
+from library_layer.utils.sqs import send_sqs_batch
 from library_layer.utils.time import unix_to_datetime
 
 logger = Logger()
@@ -170,6 +172,7 @@ class CrawlService:
 
         # ── Publish domain events (only in direct crawl path) ─────────────
         self._publish_crawl_app_events(appid, game_data, existing)
+        self._maybe_dispatch_review_crawl(appid, existing, game_data)
 
         return True
 
@@ -267,6 +270,7 @@ class CrawlService:
             return False
 
         self._publish_crawl_app_events(appid, game_data, existing)
+        self._maybe_dispatch_review_crawl(appid, existing, game_data)
 
         return True
 
@@ -496,11 +500,7 @@ class CrawlService:
             )
 
             # Detect game release: coming_soon flipped True → False
-            if (
-                existing
-                and existing["coming_soon"]
-                and not game_data.get("coming_soon", True)
-            ):
+            if existing and existing["coming_soon"] and not game_data.get("coming_soon", True):
                 publish_event(
                     self._sns,
                     topic_arn,
@@ -542,6 +542,43 @@ class CrawlService:
                     )
         except EventPublishError:
             logger.warning("Failed to publish crawl_app events", extra={"appid": appid})
+
+    def _maybe_dispatch_review_crawl(
+        self,
+        appid: int,
+        existing: dict | None,
+        game_data: dict,
+    ) -> None:
+        """Inline review-crawl dispatch from meta ingest, gated on the same delta logic
+        as find_due_reviews(). Replaces the SNS routing of GameMetadataReadyEvent /
+        GameReleasedEvent / GameUpdatedEvent → review_crawl_queue.
+        """
+        if not self._config.REFRESH_REVIEWS_ENABLED:
+            return
+
+        new_rce = int(game_data.get("review_count_english") or 0)
+        if new_rce < self._config.REFRESH_TIER_B_REVIEW_COUNT:
+            return
+        if game_data.get("coming_soon"):
+            return
+
+        review_crawled_at = existing.get("review_crawled_at") if existing else None
+        if review_crawled_at is None:
+            self._dispatch_review_crawl(appid)
+            return
+
+        last_fetch_rce = int((existing.get("review_count_at_last_fetch") if existing else 0) or 0)
+        delta = new_rce - last_fetch_rce
+        delta_met = delta >= self._config.REFRESH_REVIEWS_MIN_DELTA
+        is_stale = (datetime.now(tz=UTC) - review_crawled_at).days >= 30
+
+        if delta_met or is_stale:
+            self._dispatch_review_crawl(appid)
+
+    def _dispatch_review_crawl(self, appid: int) -> None:
+        msg = ReviewCrawlMessage(appid=appid, source="refresh").model_dump()
+        send_sqs_batch(self._sqs, self._review_queue_url, [msg])
+        logger.info("inline_review_dispatch enqueued", extra={"appid": appid})
 
     def _trigger_analysis(self, appid: int, game_name: str) -> str | None:
         """Start Step Functions execution. Returns execution ARN or None if SFN not configured."""

--- a/src/library-layer/library_layer/services/crawl_service.py
+++ b/src/library-layer/library_layer/services/crawl_service.py
@@ -556,8 +556,10 @@ class CrawlService:
         if not self._config.REFRESH_REVIEWS_ENABLED:
             return
 
+        # Tier B eligibility uses total review_count (find_due_reviews:200), delta uses English (find_due_reviews:213).
+        new_review_count = int(game_data.get("review_count") or 0)
         new_rce = int(game_data.get("review_count_english") or 0)
-        if new_rce < self._config.REFRESH_TIER_B_REVIEW_COUNT:
+        if new_review_count < self._config.REFRESH_TIER_B_REVIEW_COUNT:
             return
         if game_data.get("coming_soon"):
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ _TEST_ENV_DEFAULTS = {
     "SPOKE_RESULTS_QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123456789012/spoke-results",
     "SPOKE_REGIONS": "us-east-1",
     "SPOKE_CRAWL_QUEUE_URLS": "https://sqs.us-east-1.amazonaws.com/123456789012/steampulse-spoke-crawl-us-east-1-test",
+    "REFRESH_REVIEWS_ENABLED": "true",
 }
 for _k, _v in _TEST_ENV_DEFAULTS.items():
     os.environ.setdefault(_k, _v)

--- a/tests/infra/test_compute_stack.py
+++ b/tests/infra/test_compute_stack.py
@@ -60,6 +60,7 @@ def template() -> assertions.Template:
         SYSTEM_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/system-events-topic-arn",
         EMAIL_QUEUE_PARAM_NAME="/steampulse/test/messaging/email-queue-url",
         SPOKE_CRAWL_QUEUE_URLS="https://sqs.us-east-1.amazonaws.com/123456789012/steampulse-spoke-crawl-us-east-1-production",
+        REFRESH_REVIEWS_ENABLED=True,
     )
     compute = ComputeStack(
         app,

--- a/tests/infra/test_messaging_stack.py
+++ b/tests/infra/test_messaging_stack.py
@@ -33,6 +33,7 @@ def _synth_messaging_stack() -> assertions.Template:
         GAME_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/game-events-topic-arn",
         CONTENT_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/content-events-topic-arn",
         SYSTEM_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/system-events-topic-arn",
+        REFRESH_REVIEWS_ENABLED=False,
     )
     stack = MessagingStack(app, "TestMessaging", config=config)
     return assertions.Template.from_stack(stack)
@@ -53,12 +54,11 @@ def test_messaging_stack_creates_3_topics() -> None:
 def test_messaging_stack_creates_subscriptions_with_filters() -> None:
     """SNS subscriptions use event_type filter policies (test 45)."""
     template = _synth_messaging_stack()
-    # 4 subscriptions: metadata-enrichment, review-crawl ($or CfnSubscription),
-    # batch-staging, frontend-revalidation (report-ready).
-    # cache-invalidation subscription removed — matview refresh auto-schedule
-    # disabled; operator drives REFRESH from local cron.
+    # 3 subscriptions: metadata-enrichment, batch-staging, frontend-revalidation (report-ready).
+    # review-crawl SNS bridge removed — review_crawl_queue is fed by inline Python dispatch.
+    # cache-invalidation removed — matview refresh runs from local cron.
     subs = template.find_resources("AWS::SNS::Subscription")
-    assert len(subs) == 4, f"Expected 4 subscriptions, got {len(subs)}"
+    assert len(subs) == 3, f"Expected 3 subscriptions, got {len(subs)}"
 
     # Every subscription must have a FilterPolicy
     for logical_id, resource in subs.items():
@@ -66,38 +66,23 @@ def test_messaging_stack_creates_subscriptions_with_filters() -> None:
         assert "FilterPolicy" in props, f"{logical_id} missing FilterPolicy"
 
 
-# ── Test 46: review-crawl-queue has 2 subscriptions with correct filters ──────
+# ── Test 46: review-crawl-queue has no SNS subscription (inline dispatch only) ──
 
 
-def test_messaging_stack_review_crawl_filter() -> None:
-    """Review-crawl-queue has ONE $or subscription covering both filter conditions (test 46)."""
+def test_messaging_stack_no_review_crawl_subscription() -> None:
+    """review_crawl_queue is fed by inline Python dispatch from CrawlService — no SNS bridge."""
     template = _synth_messaging_stack()
     subs = template.find_resources("AWS::SNS::Subscription")
 
-    review_crawl_subs = []
     for _logical_id, resource in subs.items():
         props = resource["Properties"]
-        # CfnSubscription stores endpoint as a plain string ARN token
-        endpoint = props.get("Endpoint", "")
         filter_policy = props.get("FilterPolicy", {})
-        fp_str = str(filter_policy)
-        if "ReviewCrawl" in fp_str or "ReviewCrawl" in str(endpoint):
-            review_crawl_subs.append(filter_policy)
-        # Also catch by $or key presence combined with both event types in the policy
-        elif "$or" in filter_policy:
-            review_crawl_subs.append(filter_policy)
-
-    assert len(review_crawl_subs) == 1, (
-        f"Expected 1 review-crawl $or subscription, got {len(review_crawl_subs)}"
-    )
-
-    fp = review_crawl_subs[0]
-    fp_str = str(fp)
-    assert "$or" in fp, f"Expected $or filter policy, got: {fp}"
-    assert "game-metadata-ready" in fp_str, "Missing game-metadata-ready condition"
-    assert "is_eligible" in fp_str, "Missing is_eligible condition"
-    assert "game-released" in fp_str, "Missing game-released condition"
-    assert "game-updated" in fp_str, "Missing game-updated condition"
+        assert "$or" not in filter_policy, (
+            f"Found $or filter policy (legacy review-crawl bridge): {filter_policy}"
+        )
+        assert "game-released" not in str(filter_policy), (
+            f"Found game-released routing (should be inline only): {filter_policy}"
+        )
 
 
 # ── Test 50: SSM param for eligibility threshold ──────────────────────────────

--- a/tests/infra/test_monitoring_stack.py
+++ b/tests/infra/test_monitoring_stack.py
@@ -31,6 +31,7 @@ _TEST_CONFIG = SteamPulseConfig(
     SYSTEM_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/system-events-topic-arn",
     EMAIL_QUEUE_PARAM_NAME="/steampulse/test/messaging/email-queue-url",
     SPOKE_REGIONS="us-west-2,us-east-1",
+    REFRESH_REVIEWS_ENABLED=False,
 )
 
 

--- a/tests/infra/test_spoke_stack.py
+++ b/tests/infra/test_spoke_stack.py
@@ -30,6 +30,7 @@ _TEST_CONFIG = SteamPulseConfig(
     CONTENT_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/content-events-topic-arn",
     SYSTEM_EVENTS_TOPIC_PARAM_NAME="/steampulse/test/messaging/system-events-topic-arn",
     SPOKE_CRAWL_QUEUE_URLS="https://sqs.us-east-1.amazonaws.com/123456789012/steampulse-spoke-crawl-us-east-1-staging",
+    REFRESH_REVIEWS_ENABLED=False,
 )
 
 

--- a/tests/services/test_catalog_service.py
+++ b/tests/services/test_catalog_service.py
@@ -36,6 +36,7 @@ _REQUIRED_FIELDS: dict = {
     "GAME_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/game-events-topic-arn",
     "CONTENT_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/content-events-topic-arn",
     "SYSTEM_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/system-events-topic-arn",
+    "REFRESH_REVIEWS_ENABLED": True,
 }
 
 
@@ -252,9 +253,7 @@ def test_enqueue_refresh_reviews_tags_source_refresh(
     catalog_repo.conn.commit()
 
     with httpx.Client() as http_client:
-        svc = _make_service(
-            catalog_repo, sqs, app_q, http_client, review_queue_url=rev_q
-        )
+        svc = _make_service(catalog_repo, sqs, app_q, http_client, review_queue_url=rev_q)
         count = svc.enqueue_refresh_reviews(limit=10)
 
     assert count == 2
@@ -289,9 +288,7 @@ def test_enqueue_refresh_reviews_skips_coming_soon(
     catalog_repo.conn.commit()
 
     with httpx.Client() as http_client:
-        svc = _make_service(
-            catalog_repo, sqs, app_q, http_client, review_queue_url=rev_q
-        )
+        svc = _make_service(catalog_repo, sqs, app_q, http_client, review_queue_url=rev_q)
         count = svc.enqueue_refresh_reviews(limit=10)
 
     assert count == 0

--- a/tests/services/test_crawl_service.py
+++ b/tests/services/test_crawl_service.py
@@ -776,13 +776,17 @@ def test_maybe_dispatch_kill_switch_off_never_dispatches() -> None:
         svc._maybe_dispatch_review_crawl(
             appid=440,
             existing=None,
-            game_data={"review_count_english": 10_000, "coming_soon": False},
+            game_data={
+                "review_count": 10_000,
+                "review_count_english": 10_000,
+                "coming_soon": False,
+            },
         )
         assert _read_queue_messages(sqs, queue_url) == []
 
 
 def test_maybe_dispatch_below_tier_b_threshold_no_dispatch() -> None:
-    """Below the tier-B (=eligibility) threshold means tier C — never refresh reviews."""
+    """Below the tier-B (=eligibility) threshold on TOTAL review_count means tier C."""
     import boto3
 
     with mock_aws():
@@ -791,13 +795,36 @@ def test_maybe_dispatch_below_tier_b_threshold_no_dispatch() -> None:
         svc = _make_service_for_dispatch(
             refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
         )
-        # Threshold defaults to 50 (REVIEW_ELIGIBILITY_THRESHOLD).
+        # Threshold defaults to 50 (REVIEW_ELIGIBILITY_THRESHOLD). Eligibility gates on
+        # review_count (total all-language), matching find_due_reviews().
         svc._maybe_dispatch_review_crawl(
             appid=440,
             existing=None,
-            game_data={"review_count_english": 49, "coming_soon": False},
+            game_data={"review_count": 49, "review_count_english": 49, "coming_soon": False},
         )
         assert _read_queue_messages(sqs, queue_url) == []
+
+
+def test_maybe_dispatch_eligible_by_total_review_count_even_when_english_below_threshold() -> None:
+    """Tier B eligibility uses TOTAL review_count, not English — matches find_due_reviews()."""
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-total-vs-eng")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        # 60 total reviews ≥ 50 threshold → tier B eligible. Only 30 English — irrelevant
+        # for the eligibility gate; would have been wrongly skipped if gate used English.
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing=None,
+            game_data={"review_count": 60, "review_count_english": 30, "coming_soon": False},
+        )
+        msgs = _read_queue_messages(sqs, queue_url)
+        assert len(msgs) == 1
+        assert msgs[0]["appid"] == 440
 
 
 def test_maybe_dispatch_coming_soon_no_dispatch() -> None:
@@ -813,7 +840,11 @@ def test_maybe_dispatch_coming_soon_no_dispatch() -> None:
         svc._maybe_dispatch_review_crawl(
             appid=440,
             existing=None,
-            game_data={"review_count_english": 10_000, "coming_soon": True},
+            game_data={
+                "review_count": 10_000,
+                "review_count_english": 10_000,
+                "coming_soon": True,
+            },
         )
         assert _read_queue_messages(sqs, queue_url) == []
 
@@ -831,7 +862,7 @@ def test_maybe_dispatch_first_fetch_dispatches_when_existing_is_none() -> None:
         svc._maybe_dispatch_review_crawl(
             appid=440,
             existing=None,
-            game_data={"review_count_english": 200, "coming_soon": False},
+            game_data={"review_count": 200, "review_count_english": 200, "coming_soon": False},
         )
         msgs = _read_queue_messages(sqs, queue_url)
         assert len(msgs) == 1
@@ -857,7 +888,7 @@ def test_maybe_dispatch_first_fetch_dispatches_when_review_crawled_at_is_none() 
                 "review_crawled_at": None,
                 "review_count_at_last_fetch": None,
             },
-            game_data={"review_count_english": 200, "coming_soon": False},
+            game_data={"review_count": 200, "review_count_english": 200, "coming_soon": False},
         )
         msgs = _read_queue_messages(sqs, queue_url)
         assert len(msgs) == 1
@@ -886,7 +917,7 @@ def test_maybe_dispatch_delta_below_min_and_not_stale_no_dispatch() -> None:
                 "review_crawled_at": datetime.now(tz=UTC) - timedelta(days=5),
                 "review_count_at_last_fetch": 4500,
             },
-            game_data={"review_count_english": 5000, "coming_soon": False},
+            game_data={"review_count": 5000, "review_count_english": 5000, "coming_soon": False},
         )
         assert _read_queue_messages(sqs, queue_url) == []
 
@@ -912,7 +943,7 @@ def test_maybe_dispatch_delta_meets_min_dispatches() -> None:
                 "review_crawled_at": datetime.now(tz=UTC) - timedelta(days=2),
                 "review_count_at_last_fetch": 4500,
             },
-            game_data={"review_count_english": 6000, "coming_soon": False},
+            game_data={"review_count": 6000, "review_count_english": 6000, "coming_soon": False},
         )
         msgs = _read_queue_messages(sqs, queue_url)
         assert len(msgs) == 1
@@ -939,7 +970,7 @@ def test_maybe_dispatch_stale_dispatches_even_below_min_delta() -> None:
                 "review_crawled_at": datetime.now(tz=UTC) - timedelta(days=31),
                 "review_count_at_last_fetch": 800,
             },
-            game_data={"review_count_english": 805, "coming_soon": False},
+            game_data={"review_count": 805, "review_count_english": 805, "coming_soon": False},
         )
         msgs = _read_queue_messages(sqs, queue_url)
         assert len(msgs) == 1

--- a/tests/services/test_crawl_service.py
+++ b/tests/services/test_crawl_service.py
@@ -5,7 +5,6 @@ import re
 from unittest.mock import MagicMock
 
 import pytest
-
 from library_layer.config import SteamPulseConfig
 from library_layer.repositories.catalog_repo import CatalogRepository
 from library_layer.repositories.game_repo import GameRepository
@@ -94,6 +93,7 @@ _REQUIRED_FIELDS: dict = {
     "GAME_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/game-events-topic-arn",
     "CONTENT_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/content-events-topic-arn",
     "SYSTEM_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/system-events-topic-arn",
+    "REFRESH_REVIEWS_ENABLED": False,
 }
 
 
@@ -722,3 +722,225 @@ def test_crawl_reviews_archives_to_s3(
     data = json.loads(decompressed)
     assert isinstance(data, list)
     assert len(data) == 4
+
+
+# ── _maybe_dispatch_review_crawl: inline review-crawl gate (mirrors find_due_reviews) ──
+
+
+def _make_service_for_dispatch(
+    *,
+    refresh_reviews_enabled: bool,
+    sqs_client: object,
+    review_queue_url: str,
+) -> CrawlService:
+    """Build a minimal CrawlService for unit-testing _maybe_dispatch_review_crawl directly."""
+    cfg = SteamPulseConfig(
+        **{**_REQUIRED_FIELDS, "REFRESH_REVIEWS_ENABLED": refresh_reviews_enabled}
+    )
+    return CrawlService(
+        game_repo=MagicMock(),
+        review_repo=MagicMock(),
+        catalog_repo=MagicMock(),
+        tag_repo=MagicMock(),
+        steam=MagicMock(),
+        sqs_client=sqs_client,
+        review_queue_url=review_queue_url,
+        sns_client=_mock_sns(),
+        config=cfg,
+        sfn_arn=None,
+        sfn_client=None,
+        s3_client=None,
+        archive_bucket=None,
+        game_events_topic_arn="arn:aws:sns:us-east-1:123456789012:game-events",
+        content_events_topic_arn="arn:aws:sns:us-east-1:123456789012:content-events",
+    )
+
+
+def _read_queue_messages(sqs_client: object, queue_url: str) -> list[dict]:
+    """Drain whatever messages are currently in the queue (max 10) and return parsed bodies."""
+    resp = sqs_client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=0)
+    return [json.loads(m["Body"]) for m in resp.get("Messages", [])]
+
+
+def test_maybe_dispatch_kill_switch_off_never_dispatches() -> None:
+    """REFRESH_REVIEWS_ENABLED=False short-circuits before any gate check."""
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-killswitch")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=False, sqs_client=sqs, review_queue_url=queue_url
+        )
+        # Conditions that would otherwise dispatch (first-fetch eligible game)
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing=None,
+            game_data={"review_count_english": 10_000, "coming_soon": False},
+        )
+        assert _read_queue_messages(sqs, queue_url) == []
+
+
+def test_maybe_dispatch_below_tier_b_threshold_no_dispatch() -> None:
+    """Below the tier-B (=eligibility) threshold means tier C — never refresh reviews."""
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-below-b")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        # Threshold defaults to 50 (REVIEW_ELIGIBILITY_THRESHOLD).
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing=None,
+            game_data={"review_count_english": 49, "coming_soon": False},
+        )
+        assert _read_queue_messages(sqs, queue_url) == []
+
+
+def test_maybe_dispatch_coming_soon_no_dispatch() -> None:
+    """Pre-launch games have no reviews to refresh."""
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-coming-soon")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing=None,
+            game_data={"review_count_english": 10_000, "coming_soon": True},
+        )
+        assert _read_queue_messages(sqs, queue_url) == []
+
+
+def test_maybe_dispatch_first_fetch_dispatches_when_existing_is_none() -> None:
+    """Brand-new game (no prior row) is a first fetch — dispatch."""
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-first-none")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing=None,
+            game_data={"review_count_english": 200, "coming_soon": False},
+        )
+        msgs = _read_queue_messages(sqs, queue_url)
+        assert len(msgs) == 1
+        assert msgs[0]["appid"] == 440
+        assert msgs[0]["source"] == "refresh"
+
+
+def test_maybe_dispatch_first_fetch_dispatches_when_review_crawled_at_is_none() -> None:
+    """Existing game with no app_catalog row (LEFT JOIN nulls) is also a first fetch."""
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-first-null-rca")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing={
+                "coming_soon": False,
+                "review_count_english": 200,
+                "review_crawled_at": None,
+                "review_count_at_last_fetch": None,
+            },
+            game_data={"review_count_english": 200, "coming_soon": False},
+        )
+        msgs = _read_queue_messages(sqs, queue_url)
+        assert len(msgs) == 1
+        assert msgs[0]["appid"] == 440
+
+
+def test_maybe_dispatch_delta_below_min_and_not_stale_no_dispatch() -> None:
+    """Cumulative delta below MIN_DELTA on a recently-fetched game is a no-op."""
+    from datetime import UTC, datetime, timedelta
+
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-delta-low")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        # MIN_DELTA defaults to 1000; delta = 5000 - 4500 = 500 < 1000.
+        # Last fetch 5 days ago — not stale (< 30d).
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing={
+                "coming_soon": False,
+                "review_count_english": 4500,
+                "review_crawled_at": datetime.now(tz=UTC) - timedelta(days=5),
+                "review_count_at_last_fetch": 4500,
+            },
+            game_data={"review_count_english": 5000, "coming_soon": False},
+        )
+        assert _read_queue_messages(sqs, queue_url) == []
+
+
+def test_maybe_dispatch_delta_meets_min_dispatches() -> None:
+    """Cumulative delta crossing MIN_DELTA dispatches even on a recently-fetched game."""
+    from datetime import UTC, datetime, timedelta
+
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-delta-met")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        # delta = 6000 - 4500 = 1500 ≥ 1000 default MIN_DELTA.
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing={
+                "coming_soon": False,
+                "review_count_english": 4500,
+                "review_crawled_at": datetime.now(tz=UTC) - timedelta(days=2),
+                "review_count_at_last_fetch": 4500,
+            },
+            game_data={"review_count_english": 6000, "coming_soon": False},
+        )
+        msgs = _read_queue_messages(sqs, queue_url)
+        assert len(msgs) == 1
+        assert msgs[0]["appid"] == 440
+
+
+def test_maybe_dispatch_stale_dispatches_even_below_min_delta() -> None:
+    """30-day staleness floor fires even when delta is small — safety net for slow growers."""
+    from datetime import UTC, datetime, timedelta
+
+    import boto3
+
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="rcq-stale")["QueueUrl"]
+        svc = _make_service_for_dispatch(
+            refresh_reviews_enabled=True, sqs_client=sqs, review_queue_url=queue_url
+        )
+        svc._maybe_dispatch_review_crawl(
+            appid=440,
+            existing={
+                "coming_soon": False,
+                "review_count_english": 800,
+                "review_crawled_at": datetime.now(tz=UTC) - timedelta(days=31),
+                "review_count_at_last_fetch": 800,
+            },
+            game_data={"review_count_english": 805, "coming_soon": False},
+        )
+        msgs = _read_queue_messages(sqs, queue_url)
+        assert len(msgs) == 1
+        assert msgs[0]["appid"] == 440

--- a/tests/services/test_crawl_service_events.py
+++ b/tests/services/test_crawl_service_events.py
@@ -108,6 +108,7 @@ def _test_config(**overrides: Any) -> SteamPulseConfig:
         "CONTENT_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/content-events-topic-arn",
         "SYSTEM_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/system-events-topic-arn",
         "REVIEW_ELIGIBILITY_THRESHOLD": 500,
+        "REFRESH_REVIEWS_ENABLED": False,
     }
     defaults.update(overrides)
     # Keep tier-B threshold in lock-step with REVIEW_ELIGIBILITY_THRESHOLD

--- a/tests/services/test_ingest_spoke.py
+++ b/tests/services/test_ingest_spoke.py
@@ -21,6 +21,7 @@ _REQUIRED_FIELDS: dict = {
     "GAME_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/game-events-topic-arn",
     "CONTENT_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/content-events-topic-arn",
     "SYSTEM_EVENTS_TOPIC_PARAM_NAME": "/steampulse/test/messaging/system-events-topic-arn",
+    "REFRESH_REVIEWS_ENABLED": False,
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ _ALL_REQUIRED = {
     "LLM_MODEL__CHUNKING": "anthropic.claude-haiku-test-v1:0",
     "LLM_MODEL__SUMMARIZER": "anthropic.claude-sonnet-test-v1:0",
     "LLM_MODEL__GENRE_SYNTHESIS": "anthropic.claude-sonnet-test-v1:0",
+    "REFRESH_REVIEWS_ENABLED": True,
 }
 
 
@@ -109,6 +110,16 @@ def test_refresh_reviews_min_delta_zero_rejected() -> None:
     with pytest.raises(ValidationError) as exc:
         SteamPulseConfig(**_ALL_REQUIRED, REFRESH_REVIEWS_MIN_DELTA=0)
     assert "REFRESH_REVIEWS_MIN_DELTA" in str(exc.value)
+
+
+def test_refresh_reviews_enabled_is_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REFRESH_REVIEWS_ENABLED has no default — every env file must wire it explicitly."""
+    monkeypatch.delenv("REFRESH_REVIEWS_ENABLED", raising=False)
+    with pytest.raises(ValidationError) as exc:
+        SteamPulseConfig(
+            **{k: v for k, v in _ALL_REQUIRED.items() if k != "REFRESH_REVIEWS_ENABLED"}
+        )
+    assert "REFRESH_REVIEWS_ENABLED" in str(exc.value)
 
 
 def test_model_for_returns_configured_model_for_genre_synthesis() -> None:

--- a/tiered-refresh-schedule.org
+++ b/tiered-refresh-schedule.org
@@ -7,14 +7,22 @@ Hourly dispatcher that smears work across each tier's refresh window via
 
 * Tiers (first match wins)
 
-| Tier | Membership                                                 | Meta    | Reviews |
-|------+------------------------------------------------------------+---------+---------|
-| S    | review_count ≥ 10,000                                      | 2 days  | 1 day   |
-| A    | coming_soon OR EA genre OR review_count ≥ 1,000            | 7 days  | 3 days  |
-| B    | review_count ≥ 50                                          | 21 days | 14 days |
-| C    | everything else                                            | 90 days | —       |
+| Tier | Membership                                                 | Meta    | Reviews* |
+|------+------------------------------------------------------------+---------+----------|
+| S    | review_count ≥ 10,000                                      | 2 days  | 1 day    |
+| A    | coming_soon OR EA genre OR review_count ≥ 1,000            | 7 days  | 3 days   |
+| B    | review_count ≥ 50                                          | 21 days | 14 days  |
+| C    | everything else                                            | 90 days | —        |
 
 Reviews additionally exclude =coming_soon= (no reviews to refresh yet).
+
+\* Review tier intervals govern only the operator-triggered drain
+(=sp.py refresh-reviews= → =enqueue_refresh_reviews(limit=)=). The
+steady-state review pipeline dispatches *inline from meta ingest* via
+=CrawlService._maybe_dispatch_review_crawl=, gated on the same delta logic
+as =find_due_reviews()= and on the =REFRESH_REVIEWS_ENABLED= kill-switch.
+So in practice, steady-state review refetch cadence = meta cadence (S=2d /
+A=7d / B=21d) when the delta gate trips.
 
 * Catalog populations (measured pre-ship)
 
@@ -63,13 +71,19 @@ between metadata and reviews. Every message fans out to the spoke pipeline
 
 * Hourly dispatch (what it looks like all week)
 
-Two EventBridge rules fire every hour, independently:
+One EventBridge rule fires every hour:
 
-- =RefreshMetaRule=    → crawler Lambda → =enqueue_refresh_meta(limit=600)=
-- =RefreshReviewsRule= → crawler Lambda → =enqueue_refresh_reviews(limit=500)=
+- =RefreshMetaRule= → crawler Lambda → =enqueue_refresh_meta(limit=600)=
 
-The dispatcher sorts due candidates by tier_rank (S=0 → C=3), so S always wins
-when batch headroom is tight. Within a tier, oldest-due-first.
+The meta dispatcher sorts due candidates by tier_rank (S=0 → C=3), so S
+always wins when batch headroom is tight. Within a tier, oldest-due-first.
+
+Review dispatch is *not* on a cron — it fires inline from meta ingest
+(=CrawlService._maybe_dispatch_review_crawl=) whenever the just-ingested
+row's cumulative review delta crosses =REFRESH_REVIEWS_MIN_DELTA= (or it's
+a first fetch / 30-day staleness). The legacy =RefreshReviewsRule= cron
+and =ReviewCrawlSub= SNS bridge have both been removed; review-crawl-queue
+is now fed only by inline Python dispatch and operator drains.
 
 #+begin_src text
 Hour:   00  01  02  03  04  05  06  07  08  09  10  11  12  13  14  15  16  17  18  19  20  21  22  23
@@ -83,11 +97,17 @@ batch. Hour-by-hour shape = flat, day-by-day shape = flat.
 
 * What to watch
 
-The dispatcher logs one line per hour per kind:
+The meta dispatcher logs one line per hour:
 
 #+begin_src text
 refresh_meta enqueued    enqueued=486 limit=600 oldest_due_age_hours=3.2 dispatched_by_tier={S:11, A:357, B:87, C:31, unknown:0}
-refresh_reviews enqueued enqueued=402 limit=500 oldest_due_age_hours=8.1 dispatched_by_tier={S:79, A:239, B:84, C:0,  unknown:0}
+#+end_src
+
+Inline review dispatch logs one line per dispatched appid (subset of meta
+ingests — only those that pass the delta gate):
+
+#+begin_src text
+inline_review_dispatch enqueued    appid=440
 #+end_src
 
 - =enqueued= near =limit= for multiple hours → demand outgrowing capacity.


### PR DESCRIPTION
Carefully check this PR!!  It implements prompt at: scripts/prompts/inline-review-dispatch-from-meta.md.

Specific things to check:

- **Delta gate semantics** — `_maybe_dispatch_review_crawl` (`src/library-layer/library_layer/services/crawl_service.py`) uses `review_count_at_last_fetch` (cumulative since last review crawl, on `app_catalog`) — NOT `games.review_count_english` pre-upsert. The latter would be a per-ingest delta and would essentially never cross `REFRESH_REVIEWS_MIN_DELTA=1000`, leaving the gate effectively closed. Confirm this matches `find_due_reviews()` in `catalog_repo.py:155-229`.
- **`find_event_snapshot` LEFT JOIN** — `src/library-layer/library_layer/repositories/game_repo.py:144` now joins `app_catalog` to pull `review_crawled_at` and `review_count_at_last_fetch`. LEFT JOIN (not INNER) so games without an `app_catalog` row still return a snapshot (both columns come back as `None`, treated as first-fetch).
- **Kill-switch wiring** — `REFRESH_REVIEWS_ENABLED` is required (no default per `feedback_no_field_defaults`). Wired into `.env.example=true`, `.env.staging=false` (CI validation only), `.env.production=true`. Local `.env` is gitignored. Validate that the propagated `REFRESH_REVIEWS_ENABLED` env var lands on every Lambda (cdk diff confirms this).
- **Both call sites wired** — `_maybe_dispatch_review_crawl` is called after `_publish_crawl_app_events` in BOTH `crawl_app` (direct path) and `ingest_spoke_metadata` (spoke result path) — these are the two producers of the old `GameMetadataReadyEvent` SNS routing.
- **Infra deletes** — `cdk diff` shows exactly: `RefreshReviewsRule` + permission destroyed (Compute), `ReviewCrawlSub` CfnSubscription + `ReviewCrawlQueuePolicy` (the SNS service-principal grant) destroyed (Messaging). LibraryLayer re-uploaded for the library code changes. The `refresh_reviews` action handler in CrawlerFn stays — `sp.py refresh-reviews` operator path still routes through it. Note: an incidental `CACHE_BUCKET_KEY_PREFIX` flip from `cache/9a1eeda/` → `cache/local/` appears because `cdk diff` ran without `--context build-id=...`; reconciles on real deploy.
- **`game-released` / `game-updated` routing removed** — `GameReleasedEvent` is still published (`crawl_service.py:507`); only its review-crawl SNS routing was removed. `GameUpdatedEvent` was never published from any active code path; the model definition stays for a possible future revival.
- **Tests** — 8 new helper tests covering kill-switch, tier B threshold, coming_soon, two first-fetch shapes (existing=None and review_crawled_at=None), delta-met, delta-unmet, and 30-day staleness. Hit `steampulse_test` per `feedback_test_db.md`. Full suite: 696 passed.
- **Docs** — `tiered-refresh-schedule.org` and `ARCHITECTURE.org` updated to reflect the new topology (no review cron, no SNS bridge, inline dispatch only).

Out of scope (not touched by this PR):
- Review tier-window config (`REFRESH_REVIEWS_TIER_S/A/B_DAYS`) — operator drain `sp.py refresh-reviews` still uses these.
- `RefreshMetaRule` cadence and `find_due_meta()` semantics — unchanged.
- Backfill — none needed; 0055 migration already initialized `review_count_at_last_fetch`. Cold deploy: first meta pass per game observes delta=0 → no dispatch unless real growth has accrued.