### PR TITLE
feature/plausible-analytics-pre-launch: add Plausible analytics via f…

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Fraunces, Inter, JetBrains_Mono } from "next/font/google";
 import { Navbar } from "@/components/layout/Navbar";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import PlausibleProvider from "next-plausible";
 import "./globals.css";
 
 const websiteJsonLd = {
@@ -99,10 +100,14 @@ export default function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
-        <NuqsAdapter>
-          <Navbar />
-          {children}
-        </NuqsAdapter>
+        <PlausibleProvider
+          enabled={process.env.NEXT_PUBLIC_PLAUSIBLE_ENABLED === "true"}
+        >
+          <NuqsAdapter>
+            <Navbar />
+            {children}
+          </NuqsAdapter>
+        </PlausibleProvider>
       </body>
     </html>
   );

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import type { NextConfig } from "next";
+import { withPlausibleProxy } from "next-plausible";
 
 // Pin Next BUILD_ID to git short SHA — same value CACHE_BUCKET_KEY_PREFIX
 // uses, so OpenNext tag namespaces stay aligned across deploys and
@@ -54,4 +55,8 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withPlausibleProxy({
+  src: "https://plausible.io/js/pa-fdpH1ur-zxTFCitvrhP8d.js",
+  scriptPath: "/stats/js/script.js",
+  apiPath: "/stats/api/event",
+})(nextConfig);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^0.577.0",
         "motion": "^12.36.0",
         "next": "16.1.6",
+        "next-plausible": "^4.0.0",
         "nuqs": "^2.8.9",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -7386,6 +7387,20 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-4.0.0.tgz",
+      "integrity": "sha512-tC48VscREZ4fEvas9T4oj5qJwnpPlms0Wih1Unbgi/ozG08yN1w0IAPGp+/cHB8n6qzEAL5J0MlAS0FOr132jA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 ",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.577.0",
     "motion": "^12.36.0",
     "next": "16.1.6",
+    "next-plausible": "^4.0.0",
     "nuqs": "^2.8.9",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -54,6 +54,9 @@ export default defineConfig({
       env: {
         ...process.env as Record<string, string>,
         API_URL: 'http://localhost:3001',
+        // Defense-in-depth: never load Plausible during e2e runs, even if
+        // the surrounding shell has NEXT_PUBLIC_PLAUSIBLE_ENABLED=true set.
+        NEXT_PUBLIC_PLAUSIBLE_ENABLED: 'false',
       },
     },
   ],

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -104,8 +104,12 @@ if [[ "$SKIP_FRONTEND" == "false" ]]; then
     # missing build-manifest.json errors during open-next bundling.
     rm -rf .next .open-next
     # Plausible analytics: production-only, never fire in staging.
+    # Always set explicitly so a leaky CI/shell export can't pollute a
+    # non-production build.
     if [[ "$ENV" == "production" ]]; then
         export NEXT_PUBLIC_PLAUSIBLE_ENABLED=true
+    else
+        unset NEXT_PUBLIC_PLAUSIBLE_ENABLED
     fi
     npm run build:open-next
     cd "$REPO_ROOT"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -103,6 +103,10 @@ if [[ "$SKIP_FRONTEND" == "false" ]]; then
     # "Module not found: @vercel/turbopack-next/internal/font/..." or
     # missing build-manifest.json errors during open-next bundling.
     rm -rf .next .open-next
+    # Plausible analytics: production-only, never fire in staging.
+    if [[ "$ENV" == "production" ]]; then
+        export NEXT_PUBLIC_PLAUSIBLE_ENABLED=true
+    fi
     npm run build:open-next
     cd "$REPO_ROOT"
     echo "✓ Frontend build complete"

--- a/scripts/prompts/plausible-analytics-pre-launch.md
+++ b/scripts/prompts/plausible-analytics-pre-launch.md
@@ -1,0 +1,181 @@
+# Plausible Analytics Integration (Pre-Launch)
+
+## Goal
+
+Wire Plausible Analytics into the Next.js frontend before the `steampulse.io`
+domain is cut over in Route53. When DNS flips, analytics is already live —
+no day-one tracking gap. Use **proxy mode** so the script is served from our
+own domain and isn't blocked by uBlock Origin / Brave / AdGuard (gamer
+audience → high adblock penetration).
+
+## Background
+
+- Phase 5 launch task per `scripts/launch-checklist.org` lines 188-193
+  (the raw `<script>` snippet there is superseded by this prompt)
+- Privacy-friendly, cookieless — no GDPR banner required
+- $9/mo (Growth plan)
+- Frontend: Next.js 16.1.6 App Router → OpenNext → CloudFront + S3
+- No analytics exists today (only JSON-LD structured data in the layout)
+- Domain `steampulse.io` is hardcoded across `metadataBase`, JSON-LD,
+  `sitemap.ts`, `robots.ts`
+
+## Prerequisites (user-side)
+
+1. Sign up at https://plausible.io and add `steampulse.io` as a site.
+2. From the dashboard, copy the **site-specific script URL** — it looks
+   like `https://plausible.io/js/pa-XXXXX.js`. Plausible v4 bakes per-site
+   feature config (outbound links, file downloads, etc.) into this URL,
+   configured in the dashboard rather than as code props.
+3. **Skip the dashboard "Verify" step** — it fetches `https://steampulse.io`
+   to look for the script, which fails today because DNS isn't cut over yet.
+   Verification will succeed automatically once DNS is live and a real
+   pageview hits.
+
+## Implementation
+
+Use [`next-plausible`](https://github.com/4lejandrito/next-plausible) v4.
+It provides `withPlausibleProxy` for Next.js rewrites and a
+`<PlausibleProvider>` that auto-uses the proxied URLs when the proxy is
+configured.
+
+### 1. Install
+
+```bash
+cd frontend && npm install next-plausible
+```
+
+(The frontend uses npm — `package-lock.json` is the lockfile, despite some
+docs referencing `bun`.)
+
+### 2. Configure the proxy in `frontend/next.config.ts`
+
+Wrap the existing `nextConfig` export with `withPlausibleProxy`. Pass:
+- `src` — the site-specific script URL from the Plausible dashboard.
+- `scriptPath` and `apiPath` overriding the defaults (`/js/script.js`,
+  `/api/event`) to live under `/stats/*`. This avoids collision with the
+  existing FastAPI `/api/*` dev rewrite at `next.config.ts:42-50`.
+
+```ts
+import { withPlausibleProxy } from "next-plausible";
+
+// ...existing nextConfig declaration unchanged...
+
+export default withPlausibleProxy({
+  src: "https://plausible.io/js/pa-XXXXX.js",
+  scriptPath: "/stats/js/script.js",
+  apiPath: "/stats/api/event",
+})(nextConfig);
+```
+
+The wrapper adds Next.js rewrites internally:
+- `GET /stats/js/script.js` → fetches upstream `pa-XXXXX.js` and serves it
+- `POST /stats/api/event` → forwards to `https://plausible.io/api/event`
+
+### 3. Mount the provider in `frontend/app/layout.tsx`
+
+Gate the provider on `NEXT_PUBLIC_PLAUSIBLE_ENABLED` so it only fires in
+the production build — same posture as the `is_production` gate on
+EventBridge rules per `feedback_no_staging_schedules`. Without this gate,
+a future staging deploy would pollute prod analytics with QA traffic
+(Plausible only auto-ignores `localhost`, not `staging.*` subdomains).
+
+```tsx
+import PlausibleProvider from "next-plausible";
+
+// ...inside <body>, wrapping the existing tree:
+<PlausibleProvider
+  enabled={process.env.NEXT_PUBLIC_PLAUSIBLE_ENABLED === "true"}
+>
+  <NuqsAdapter>
+    <Navbar />
+    {children}
+  </NuqsAdapter>
+</PlausibleProvider>
+```
+
+The two existing JSON-LD `<script>` tags stay where they are — siblings to
+the provider, inside `<body>`.
+
+Outbound-link tracking, file-download tracking, etc. are **not** code
+props in v4 — toggle them in the Plausible dashboard and they get baked
+into the `pa-XXXXX.js` script automatically.
+
+### 4. Wire the env var in `scripts/deploy.sh`
+
+In Step 1 (frontend build), export the var only for production:
+
+```bash
+if [[ "$ENV" == "production" ]]; then
+    export NEXT_PUBLIC_PLAUSIBLE_ENABLED=true
+fi
+npm run build:open-next
+```
+
+Result: production builds emit the `<PlausibleProvider>` script chain;
+staging and local prod-builds emit nothing — the provider returns `null`.
+
+## Verification
+
+1. **Build:**
+   ```
+   cd frontend && npm run build
+   ```
+   Must compile cleanly (no TS errors).
+
+2. **Run prod server locally:**
+   ```
+   PORT=3737 npm run start
+   ```
+
+3. **Confirm the served HTML preloads the proxied script:**
+   ```
+   curl -s http://localhost:3737/ | grep -oE 'href="/stats/js/script.js"'
+   ```
+   Should return `href="/stats/js/script.js"` (relative path, not
+   `plausible.io`).
+
+4. **Confirm the proxy fetches & serves the right bytes:**
+   ```
+   diff <(curl -s http://localhost:3737/stats/js/script.js) \
+        <(curl -s https://plausible.io/js/pa-XXXXX.js)
+   ```
+   Should show no diff — same bytes.
+
+5. **Confirm no `/api/*` collision:**
+   ```
+   curl -sI 'http://localhost:3737/api/games?limit=1'
+   ```
+   Should hit the FastAPI dev rewrite (404 if no FastAPI running, or
+   200 if it is). Either way it must NOT be intercepted by Plausible.
+
+6. **Post-deploy (after DNS cutover — separate launch task):**
+   - Open `https://steampulse.io`
+   - DevTools → Network: script comes from `steampulse.io/stats/js/...`
+     (NOT `plausible.io`) — confirms proxy is working
+   - Plausible **Realtime** dashboard shows the pageview within ~5s
+   - The "Verify" banner in the Plausible dashboard auto-clears
+
+## Out of scope (deferred)
+
+- Custom events (Pro CTA clicks, search submissions, genre conversions).
+  Add via `usePlausible<MyEvents>()` once we know which conversions matter.
+- Move the `pa-XXXXX.js` URL to env var if it ever needs per-environment
+  values. Today it's a single production-targeted ID, hardcoded in
+  `next.config.ts`. Not a secret — appears in public `<script src>`.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `frontend/package.json` / `package-lock.json` | Add `next-plausible@^4` |
+| `frontend/next.config.ts` | Wrap export with `withPlausibleProxy({ src, scriptPath: "/stats/js/script.js", apiPath: "/stats/api/event" })` |
+| `frontend/app/layout.tsx` | Import `PlausibleProvider`, wrap `<NuqsAdapter>` tree, gate via `enabled={process.env.NEXT_PUBLIC_PLAUSIBLE_ENABLED === "true"}` |
+| `scripts/deploy.sh` | Export `NEXT_PUBLIC_PLAUSIBLE_ENABLED=true` in Step 1 only when `$ENV == "production"` |
+
+## After merge
+
+- Move this file: `scripts/prompts/plausible-analytics-pre-launch.md` →
+  `scripts/prompts/completed/`
+- Update `scripts/launch-checklist.org` lines 188-193: replace the raw
+  `<script>` snippet with a one-liner referencing the completed prompt,
+  then mark the entry `** DONE`.


### PR DESCRIPTION
Carefully check this PR!! It implements prompt at: scripts/prompts/plausible-analytics-pre-launch.md.

Site script URL is hardcoded. https://plausible.io/js/pa-fdpH1ur-zxTFCitvrhP8d.js lives in frontend/next.config.ts. Confirm this is the correct site-specific URL from the Plausible dashboard for steampulse.io (it is public — appears in the script src — so safe to commit, but verify it matches the dashboard).
/stats/* proxy paths. withPlausibleProxy is configured with scriptPath: "/stats/js/script.js" and apiPath: "/stats/api/event" to avoid colliding with the existing FastAPI /api/* rewrite at frontend/next.config.ts:42-50. Verify the deployed CloudFront distribution serves /stats/* from the Next.js runtime (not the FastAPI Lambda) — if there's a CloudFront behavior/origin split routing on /api/*, ensure no equivalent rule is intercepting /stats/*.
Production-only gate. <PlausibleProvider enabled={process.env.NEXT_PUBLIC_PLAUSIBLE_ENABLED === "true"}> in frontend/app/layout.tsx, and scripts/deploy.sh only exports NEXT_PUBLIC_PLAUSIBLE_ENABLED=true when $ENV == "production". Same posture as feedback_no_staging_schedules. Verify staging deploys (when they come back) do NOT inherit the var from CI/shell.
No DNS cutover yet. This change ships analytics into the deployed code path but steampulse.io is not yet pointed at CloudFront (Phase 5 task in scripts/launch-checklist.org:179). The Plausible dashboard "Verify" check will keep failing until DNS flips — that is expected.
Local verification done. Build passes; with the env var unset the rendered HTML contains zero plausible/stats refs; with it set, <link rel="preload" href="/stats/js/script.js"> appears and the proxied script bytes are byte-identical to upstream. /api/games?limit=1 still hits the FastAPI dev rewrite (no collision).
Outbound-link / file-download tracking is configured in the Plausible dashboard in v4, NOT as code props. If you want those features, toggle them in the dashboard — the per-site pa-XXXXX.js script will get the features baked in.