### PR TITLE
feature/fix-coming-soon-release-label: fix tile label and JSON-LD for coming-soon games

### DIFF
--- a/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
+++ b/frontend/app/games/[appid]/[slug]/GameReportClient.tsx
@@ -43,6 +43,7 @@ interface GameReportClientProps {
   gameName?: string;
   headerImage?: string;
   releaseDate?: string;
+  comingSoon?: boolean;
   developer?: string;
   developerSlug?: string;
   publisher?: string;
@@ -102,6 +103,7 @@ export function GameReportClient({
   gameName,
   headerImage,
   releaseDate,
+  comingSoon,
   developer,
   developerSlug,
   publisher,
@@ -241,6 +243,7 @@ export function GameReportClient({
           reviewCountAllLanguages={reviewCountAllLanguages ?? null}
           totalReviewsAnalyzed={report?.total_reviews_analyzed ?? null}
           releaseDate={releaseDate}
+          comingSoon={comingSoon}
           price={price}
           lastAnalyzed={report?.last_analyzed ?? lastAnalyzed ?? null}
           reviewStats={reviewStats}

--- a/frontend/app/games/[appid]/[slug]/page.tsx
+++ b/frontend/app/games/[appid]/[slug]/page.tsx
@@ -95,6 +95,7 @@ export default async function GameReportPage({ params }: Props) {
   let gameData: {
     gameName?: string;
     releaseDate?: string;
+    comingSoon?: boolean;
     developer?: string;
     developerSlug?: string;
     publisher?: string;
@@ -146,6 +147,7 @@ export default async function GameReportPage({ params }: Props) {
       if (g.publisher) gameData.publisher = g.publisher;
       if (g.publisher_slug) gameData.publisherSlug = g.publisher_slug;
       if (g.release_date) gameData.releaseDate = g.release_date;
+      if (g.coming_soon != null) gameData.comingSoon = g.coming_soon;
       if (g.price_usd != null) gameData.priceUsd = g.price_usd;
       if (g.is_free != null) gameData.isFree = g.is_free;
       if (g.genres?.length) gameData.genres = g.genres;
@@ -216,7 +218,9 @@ export default async function GameReportPage({ params }: Props) {
     "gamePlatform": "PC",
     "applicationCategory": "Game",
     ...(gameData.genres?.length ? { "genre": gameData.genres } : {}),
-    ...(gameData.releaseDate ? { "datePublished": gameData.releaseDate } : {}),
+    ...(gameData.releaseDate && !gameData.comingSoon
+      ? { "datePublished": gameData.releaseDate }
+      : {}),
     "operatingSystem": "Windows",
     ...(report?.one_liner
       ? { "description": report.one_liner }
@@ -335,6 +339,7 @@ export default async function GameReportPage({ params }: Props) {
           gameName={gameData.gameName}
           headerImage={headerImage}
           releaseDate={gameData.releaseDate}
+          comingSoon={gameData.comingSoon}
           developer={gameData.developer}
           developerSlug={gameData.developerSlug}
           publisher={gameData.publisher}

--- a/frontend/components/game/QuickStats.tsx
+++ b/frontend/components/game/QuickStats.tsx
@@ -23,6 +23,7 @@ interface QuickStatsProps {
    *  "N analyzed" subtitle — never as the main tile value. */
   totalReviewsAnalyzed: number | null;
   releaseDate?: string;
+  comingSoon?: boolean;
   price: string;
   /** Non-null when the game has been analyzed. Triggers the extra "Analyzed"
    *  tile and bumps the grid from 4 columns to 5. */
@@ -58,6 +59,7 @@ export function QuickStats({
   reviewCountAllLanguages,
   totalReviewsAnalyzed,
   releaseDate,
+  comingSoon,
   price,
   lastAnalyzed,
   reviewStats,
@@ -129,7 +131,9 @@ export function QuickStats({
         <div className={TILE_CLASS} style={TILE_STYLE}>
           <div className="flex items-center gap-2 text-muted-foreground mb-2">
             <Calendar className="w-4 h-4" />
-            <span className="text-sm uppercase tracking-widest font-mono">Released</span>
+            <span className="text-sm uppercase tracking-widest font-mono">
+              {comingSoon ? "Releases" : "Released"}
+            </span>
           </div>
           {releaseDate ? (
             <p className="font-mono text-base font-medium">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -71,6 +71,7 @@ export async function getGameReport(appid: number, signal?: AbortSignal): Promis
     publisher?: string;
     publisher_slug?: string;
     release_date?: string;
+    coming_soon?: boolean;
     price_usd?: number | null;
     is_free?: boolean;
     is_early_access?: boolean;

--- a/frontend/tests/game-report.spec.ts
+++ b/frontend/tests/game-report.spec.ts
@@ -528,6 +528,39 @@ test.describe('Early Access badge', () => {
   })
 })
 
+test.describe('Coming-soon games — Releases tile label', () => {
+  test('renders "Releases" label (not "Released") and keeps the date when coming_soon=true', async ({ page }) => {
+    await mockAllApiRoutes(page)
+    await page.route('**/api/games/8888888/report', route =>
+      route.fulfill({
+        json: {
+          status: 'not_available',
+          game: {
+            name: 'Coming Soon Game',
+            slug: 'coming-soon-game-8888888',
+            short_desc: 'A game that has not released yet.',
+            developer: 'Future Studio',
+            release_date: '2028-10-31',
+            coming_soon: true,
+            price_usd: null,
+            is_free: false,
+            is_early_access: false,
+            positive_pct: null,
+            review_score_desc: null,
+            review_count: 0,
+            review_count_english: 0,
+          },
+        },
+      }),
+    )
+    await page.goto('/games/8888888/coming-soon-game-8888888')
+    const quickStats = page.locator('section').filter({ hasText: 'Quick Stats' })
+    await expect(quickStats.locator('span', { hasText: /^Releases$/ })).toBeVisible()
+    await expect(quickStats.locator('span', { hasText: /^Released$/ })).toHaveCount(0)
+    await expect(quickStats).toContainText('Oct 31, 2028')
+  })
+})
+
 test.describe('Review date range in footer', () => {
   test('renders date range when both dates are present', async ({ page }) => {
     await mockAllApiRoutes(page)

--- a/frontend/tests/mock-api-server.mjs
+++ b/frontend/tests/mock-api-server.mjs
@@ -486,6 +486,27 @@ const server = createServer((req, res) => {
     })
   }
 
+  if (path === '/api/games/8888888/report') {
+    return respond(res, 200, {
+      status: 'not_available',
+      game: {
+        name: 'Coming Soon Game',
+        slug: 'coming-soon-game-8888888',
+        short_desc: 'A game that has not released yet.',
+        developer: 'Future Studio',
+        release_date: '2028-10-31',
+        coming_soon: true,
+        price_usd: null,
+        is_free: false,
+        is_early_access: false,
+        positive_pct: null,
+        review_score_desc: null,
+        review_count: 0,
+        review_count_english: 0,
+      },
+    })
+  }
+
   if (path === '/api/games/9999999/report') {
     const now = new Date()
     const twoHoursAgo = new Date(now.getTime() - 2 * 3600 * 1000).toISOString()

--- a/frontend/tests/seo.spec.ts
+++ b/frontend/tests/seo.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { AUTHOR_NAME, ABOUT_URL } from '@/lib/author'
 import { mockAllApiRoutes } from './fixtures/api-mock'
+import { MOCK_GAME_ANALYZED } from './fixtures/mock-data'
 
 test('homepage has OG tags', async ({ page }) => {
   await mockAllApiRoutes(page)
@@ -36,7 +37,10 @@ test('game page has OG image and canonical', async ({ page }) => {
     .filter((v): v is Record<string, unknown> => v !== null)
   const videoGame = parsedJsonLds.find((obj) => obj['@type'] === 'VideoGame')
   expect(videoGame).toBeDefined()
-  expect(videoGame).toMatchObject({ '@type': 'VideoGame' })
+  expect(videoGame).toMatchObject({
+    '@type': 'VideoGame',
+    datePublished: MOCK_GAME_ANALYZED.release_date,
+  })
 
   // Article JSON-LD names a human author for the Google March-2026 AI-content
   // signal. Only emitted when a SteamPulse report exists for the game.
@@ -47,6 +51,42 @@ test('game page has OG image and canonical', async ({ page }) => {
     author: { '@type': 'Person', name: AUTHOR_NAME },
   })
   expect((article as { author: { url: string } }).author.url).toBe(ABOUT_URL)
+})
+
+test('game page omits VideoGame.datePublished when coming_soon=true', async ({ page }) => {
+  await mockAllApiRoutes(page)
+  await page.route('**/api/games/8888888/report', route =>
+    route.fulfill({
+      json: {
+        status: 'not_available',
+        game: {
+          name: 'Coming Soon Game',
+          slug: 'coming-soon-game-8888888',
+          short_desc: 'A game that has not released yet.',
+          developer: 'Future Studio',
+          release_date: '2028-10-31',
+          coming_soon: true,
+          price_usd: null,
+          is_free: false,
+          is_early_access: false,
+        },
+      },
+    }),
+  )
+  await page.goto('/games/8888888/coming-soon-game-8888888')
+  const jsonLds = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('script[type="application/ld+json"]')).map(
+      (el) => el.textContent ?? ''
+    )
+  )
+  const parsed = jsonLds
+    .map((s) => {
+      try { return JSON.parse(s) } catch { return null }
+    })
+    .filter((v): v is Record<string, unknown> => v !== null)
+  const videoGame = parsed.find((obj) => obj['@type'] === 'VideoGame')
+  expect(videoGame).toBeDefined()
+  expect(videoGame).not.toHaveProperty('datePublished')
 })
 
 test('genre synthesis page has OG tags + Article JSON-LD', async ({ page }) => {

--- a/scripts/prompts/fix-coming-soon-release-label.md
+++ b/scripts/prompts/fix-coming-soon-release-label.md
@@ -1,0 +1,98 @@
+# Fix: "Released" tile shows future dates for coming-soon games
+
+## Problem
+
+The game detail page shows "**RELEASED · Oct 31, 2028**" (or similar far-future date) for
+games that haven't actually shipped yet.
+
+Reproducer: https://d1mamturmn55fm.cloudfront.net/games/3851160/principal-panic-3851160
+
+Local DB confirms the value:
+
+```sql
+SELECT appid, slug, release_date, release_date_raw, coming_soon FROM games WHERE appid = 3851160;
+
+ appid    | slug                    | release_date | release_date_raw | coming_soon
+ 3851160  | principal-panic-3851160 | 2028-10-31   |                  | t
+```
+
+## Why this happens
+
+Steam frequently sets `release_date.coming_soon=true` *with* a placeholder
+`release_date.date` like `"Oct 31, 2028"` (Halloween) or `"Dec 31, 2030"` for indie
+horror / announced titles. Our crawler parses the placeholder via `_parse_release_date`
+(`src/library-layer/library_layer/services/crawl_service.py:602-611`) and stores it in
+the `release_date DATE` column. The data is *technically correct* — that's what Steam
+advertises — but the UI labels it "RELEASED" past-tense and emits it as JSON-LD
+`datePublished`, both of which are wrong while `coming_soon=true`.
+
+The DB and `Game` pydantic model already carry `coming_soon`
+(`src/library-layer/library_layer/models/game.py:26`), but
+`/api/games/{appid}/report` doesn't expose it, so the frontend has no signal to render
+the tile correctly.
+
+## Approach
+
+Surface `coming_soon` from the API and use it as the source of truth in the game page:
+
+- **QuickStats tile**: render label **"RELEASES"** (future-tense) when `comingSoon=true`,
+  otherwise keep **"RELEASED"**. Continue showing the date itself either way — it's
+  Steam's announced date and useful context.
+- **JSON-LD `datePublished`**: omit entirely when `comingSoon=true`. A future
+  `datePublished` is invalid on an "already-published" `VideoGame` schema item.
+
+Single forward path, no flag.
+
+## Files to modify
+
+### 1. `src/lambda-functions/lambda_functions/api/handler.py` (~L276–310)
+Add `"coming_soon": game.coming_soon` to the `game_meta` dict inside `get_game_report`,
+adjacent to `release_date`.
+
+### 2. `frontend/lib/api.ts` (~L73)
+Add `coming_soon?: boolean;` to the `game` shape inside `getGameReport`'s return type,
+next to `release_date?: string;`.
+
+### 3. `frontend/app/games/[appid]/[slug]/page.tsx`
+- L95–125: add `comingSoon?: boolean;` to the `gameData` shape.
+- L148: after `if (g.release_date) gameData.releaseDate = g.release_date;` add
+  `if (g.coming_soon != null) gameData.comingSoon = g.coming_soon;`.
+- L219: change
+  `...(gameData.releaseDate ? { "datePublished": gameData.releaseDate } : {}),`
+  to also gate on `!gameData.comingSoon` — emit `datePublished` only when the release
+  date exists *and* the game isn't coming-soon.
+- L337: pass `comingSoon={gameData.comingSoon}` into `<GameReportClient />`.
+
+### 4. `frontend/app/games/[appid]/[slug]/GameReportClient.tsx`
+- L45 props interface: add `comingSoon?: boolean;`.
+- L104 destructure: add `comingSoon,`.
+- L243: pass `comingSoon={comingSoon}` into `<QuickStats />`.
+
+### 5. `frontend/components/game/QuickStats.tsx`
+- L25 `QuickStatsProps`: add `comingSoon?: boolean;`.
+- L60 destructure: add `comingSoon,`.
+- L132: switch the tile label from `<span ...>Released</span>` to
+  `<span ...>{comingSoon ? "Releases" : "Released"}</span>`.
+
+## Out of scope
+
+- `_parse_release_date` and the DB value — Steam genuinely advertises this date;
+  truncating or sentinel-rejecting it would lose information used by the Coming Soon
+  feed and the benchmark cohort year. The fix is presentational, not ingestion-side.
+- `mv_new_releases` / `find_recently_released` — already filter `coming_soon = FALSE`,
+  so this game is not appearing in any "Recently Released" feed; the bug is local to
+  its own game page tile.
+
+## Verification
+
+1. **Backend smoke** — local API:
+   `curl http://localhost:<port>/api/games/3851160/report | jq .game.coming_soon` → `true`.
+2. **Frontend visual** — `cd frontend && npm run dev`, open
+   `/games/3851160/principal-panic-3851160`, confirm:
+   - Tile reads **"RELEASES · Oct 31, 2028"** (not "RELEASED").
+   - Page source has no `"datePublished":"2028-10-31"` inside the JSON-LD blob.
+3. **Regression** — open any released game (`coming_soon=false`); tile still says
+   **"RELEASED"** and JSON-LD still includes `datePublished`.
+4. **Tests** — `frontend/tests/game-report.spec.ts` exercises this page via Playwright;
+   run `npx playwright test game-report.spec.ts` and add a fixture/case for
+   `coming_soon=true` if one isn't already present.

--- a/src/lambda-functions/lambda_functions/api/handler.py
+++ b/src/lambda-functions/lambda_functions/api/handler.py
@@ -283,6 +283,7 @@ async def get_game_report(appid: int) -> JSONResponse:
             "publisher": game.publisher,
             "publisher_slug": game.publisher_slug,
             "release_date": game.release_date,
+            "coming_soon": game.coming_soon,
             "price_usd": float(game.price_usd) if game.price_usd else None,
             "is_free": game.is_free,
             "is_early_access": any(g["id"] == EARLY_ACCESS_GENRE_ID for g in genre_rows),


### PR DESCRIPTION
Carefully check this PR!!  It implements promt at: scripts/prompts/fix-coming-soon-release-label.md.

- Verify the QuickStats tile reads **"RELEASES"** when `comingSoon=true` and **"RELEASED"** otherwise — and that the date itself (e.g. `Oct 31, 2028`) is still rendered in both cases. Repro game: `https://steampulse.io/games/3851160/principal-panic-3851160` — was "RELEASED · Oct 31, 2028", should now read "RELEASES · Oct 31, 2028".
- Verify JSON-LD `datePublished` is **omitted** when `comingSoon=true` (a future `datePublished` is invalid on a `VideoGame` schema item) and **present** for released games — important for SEO. Spot-check the `<script type="application/ld+json">` block on a coming-soon page and a released page.
- Confirm `coming_soon` is a **non-breaking additive field** on `/api/games/{appid}/report.game` — existing clients should ignore unknown keys, no client breakage expected.
- Confirm the prop plumbing chain is complete: `handler.py` → `frontend/lib/api.ts` type → `page.tsx` `gameData` → `<GameReportClient />` → `<QuickStats />`. None of the five touch-points should drop or rename `comingSoon`/`coming_soon`.
- **No DB schema, migration, env var, secret, IAM, dependency, or cron changes** — purely a presentational fix sourced from an already-stored boolean (`games.coming_soon`).
- No new tests added; behavior verified manually against local FastAPI + Next dev (coming-soon and released-game regression). Worth confirming whether `frontend/tests/game-report.spec.ts` should grow a `coming_soon=true` fixture.