### PR TITLE
feature/waitlist-suggestion-capture: capture optional Pro suggestions in waitlist success state

### DIFF
--- a/frontend/components/home/WaitlistEmailForm.tsx
+++ b/frontend/components/home/WaitlistEmailForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { usePlausible } from "next-plausible";
-import { joinWaitlist } from "@/lib/api";
+import { joinWaitlist, submitWaitlistSuggestion } from "@/lib/api";
 
 interface WaitlistEmailFormProps {
   buttonLabel: string;
@@ -11,7 +11,14 @@ interface WaitlistEmailFormProps {
   variant?: "hero" | "repeat";
 }
 
-type Status = "idle" | "submitting" | "registered" | "already_registered";
+type Status =
+  | "idle"
+  | "submitting"
+  | "awaiting_suggestion"
+  | "sending_suggestion"
+  | "thanked";
+
+type SignupStatus = "registered" | "already_registered";
 
 export function WaitlistEmailForm({
   buttonLabel,
@@ -22,11 +29,13 @@ export function WaitlistEmailForm({
   const plausible = usePlausible();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>("idle");
+  const [signupStatus, setSignupStatus] = useState<SignupStatus>("registered");
+  const [suggestion, setSuggestion] = useState("");
   const [error, setError] = useState("");
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (status === "submitting") return; // guard re-entrancy: `disabled` only kicks in after re-render
+    if (status === "submitting") return; // guard re-entrancy
 
     const normalizedEmail = email.trim();
     setError("");
@@ -40,7 +49,8 @@ export function WaitlistEmailForm({
 
     try {
       const result = await joinWaitlist(normalizedEmail);
-      setStatus(result.status);
+      setSignupStatus(result.status);
+      setStatus("awaiting_suggestion");
       plausible("Waitlist Signup", { props: { status: result.status, variant } });
     } catch {
       setError("Something went wrong. Please try again.");
@@ -48,14 +58,83 @@ export function WaitlistEmailForm({
     }
   }
 
-  if (status === "registered" || status === "already_registered") {
+  function finishWithSkip() {
+    plausible("Waitlist Suggestion Skipped", { props: { variant } });
+    setStatus("thanked");
+  }
+
+  async function handleSuggestionSend() {
+    if (status === "sending_suggestion") return;
+
+    const trimmed = suggestion.trim();
+    if (!trimmed) {
+      finishWithSkip();
+      return;
+    }
+
+    setStatus("sending_suggestion");
+    try {
+      await submitWaitlistSuggestion(email.trim().toLowerCase(), trimmed);
+      plausible("Waitlist Suggestion", { props: { length: trimmed.length, variant } });
+      setStatus("thanked");
+    } catch {
+      // Suggestion submit failed; treat as skip so the user still sees thanks.
+      finishWithSkip();
+    }
+  }
+
+  if (status === "awaiting_suggestion" || status === "sending_suggestion") {
+    const sending = status === "sending_suggestion";
+    return (
+      <div
+        data-testid={`waitlist-suggestion-form-${variant}`}
+        className="max-w-md mx-auto text-center"
+      >
+        <p className="font-mono text-xs uppercase tracking-widest text-teal">
+          Thanks. One quick thing.
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground font-mono">
+          What would make Pro most useful for you? (Optional.)
+        </p>
+        <textarea
+          rows={3}
+          maxLength={2000}
+          value={suggestion}
+          onChange={(e) => setSuggestion(e.target.value)}
+          placeholder='e.g. "track sentiment shifts on competitors", "weekly genre digest", ...'
+          aria-label="Optional suggestion for Pro features"
+          className="mt-3 w-full px-3 py-2 rounded-lg bg-background border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-teal-400/30 text-sm font-mono resize-none"
+        />
+        <div className="mt-3 flex items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={handleSuggestionSend}
+            disabled={sending}
+            className="px-5 py-2.5 rounded-lg font-mono uppercase tracking-widest text-xs transition-colors disabled:opacity-50 bg-teal text-background"
+          >
+            {sending ? "Sending..." : "Send"}
+          </button>
+          <button
+            type="button"
+            onClick={finishWithSkip}
+            disabled={sending}
+            className="px-3 py-2.5 font-mono uppercase tracking-widest text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            Skip
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "thanked") {
     return (
       <div
         data-testid={`waitlist-success-${variant}`}
         className="max-w-md mx-auto text-center"
       >
         <p className="font-mono text-base text-teal">
-          {status === "registered"
+          {signupStatus === "registered"
             ? "You're on the list."
             : "You're already on the list."}
         </p>

--- a/frontend/components/home/WaitlistEmailForm.tsx
+++ b/frontend/components/home/WaitlistEmailForm.tsx
@@ -32,6 +32,7 @@ export function WaitlistEmailForm({
   const [signupStatus, setSignupStatus] = useState<SignupStatus>("registered");
   const [suggestion, setSuggestion] = useState("");
   const [error, setError] = useState("");
+  const [suggestionError, setSuggestionError] = useState("");
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -61,11 +62,13 @@ export function WaitlistEmailForm({
 
   function finishWithSkip() {
     plausible("Waitlist Suggestion Skipped", { props: { variant } });
+    setSuggestionError("");
     setStatus("thanked");
   }
 
   function sendAnother() {
     setSuggestion("");
+    setSuggestionError("");
     setStatus("awaiting_suggestion");
   }
 
@@ -78,6 +81,7 @@ export function WaitlistEmailForm({
       return;
     }
 
+    setSuggestionError("");
     setStatus("sending_suggestion");
     try {
       await submitWaitlistSuggestion(email.trim().toLowerCase(), trimmed);
@@ -86,7 +90,9 @@ export function WaitlistEmailForm({
       setStatus("thanked");
     } catch (err) {
       console.error("Waitlist suggestion submit failed:", err);
-      finishWithSkip();
+      plausible("Waitlist Suggestion Failed", { props: { variant } });
+      setSuggestionError("Couldn't send. Please try again.");
+      setStatus("awaiting_suggestion");
     }
   }
 
@@ -130,6 +136,11 @@ export function WaitlistEmailForm({
             Skip
           </button>
         </div>
+        {suggestionError && (
+          <p className="mt-2 text-xs text-center" style={{ color: "#ef4444" }}>
+            {suggestionError}
+          </p>
+        )}
       </div>
     );
   }

--- a/frontend/components/home/WaitlistEmailForm.tsx
+++ b/frontend/components/home/WaitlistEmailForm.tsx
@@ -52,7 +52,8 @@ export function WaitlistEmailForm({
       setSignupStatus(result.status);
       setStatus("awaiting_suggestion");
       plausible("Waitlist Signup", { props: { status: result.status, variant } });
-    } catch {
+    } catch (err) {
+      console.error("Waitlist signup failed:", err);
       setError("Something went wrong. Please try again.");
       setStatus("idle");
     }
@@ -61,6 +62,11 @@ export function WaitlistEmailForm({
   function finishWithSkip() {
     plausible("Waitlist Suggestion Skipped", { props: { variant } });
     setStatus("thanked");
+  }
+
+  function sendAnother() {
+    setSuggestion("");
+    setStatus("awaiting_suggestion");
   }
 
   async function handleSuggestionSend() {
@@ -76,9 +82,10 @@ export function WaitlistEmailForm({
     try {
       await submitWaitlistSuggestion(email.trim().toLowerCase(), trimmed);
       plausible("Waitlist Suggestion", { props: { length: trimmed.length, variant } });
+      setSuggestion("");
       setStatus("thanked");
-    } catch {
-      // Suggestion submit failed; treat as skip so the user still sees thanks.
+    } catch (err) {
+      console.error("Waitlist suggestion submit failed:", err);
       finishWithSkip();
     }
   }
@@ -141,6 +148,14 @@ export function WaitlistEmailForm({
         <p className="mt-2 text-sm text-muted-foreground font-mono">
           We&apos;ll email you when Pro launches.
         </p>
+        <button
+          type="button"
+          onClick={sendAnother}
+          data-testid={`waitlist-send-another-${variant}`}
+          className="mt-3 font-mono uppercase tracking-widest text-xs text-muted-foreground hover:text-teal transition-colors"
+        >
+          Send another suggestion
+        </button>
       </div>
     );
   }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -397,6 +397,17 @@ export async function joinWaitlist(email: string): Promise<WaitlistResult> {
   });
 }
 
+export async function submitWaitlistSuggestion(
+  email: string,
+  suggestion: string,
+): Promise<{ status: "received" }> {
+  return apiFetch("/api/waitlist/suggestion", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, suggestion }),
+  });
+}
+
 export async function getReportRequestCount(appid: number): Promise<{ appid: number; request_count: number }> {
   return apiFetch(`/api/reports/request-count/${appid}`, { next: { revalidate: 300 } });
 }

--- a/src/lambda-functions/lambda_functions/api/handler.py
+++ b/src/lambda-functions/lambda_functions/api/handler.py
@@ -23,12 +23,13 @@ from library_layer.repositories.report_repo import ReportRepository
 from library_layer.repositories.review_repo import ReviewRepository
 from library_layer.repositories.tag_repo import TagRepository
 from library_layer.repositories.waitlist_repo import WaitlistRepository
+from library_layer.repositories.waitlist_suggestion_repo import WaitlistSuggestionRepository
 from library_layer.services.analytics_service import AnalyticsService
 from library_layer.services.catalog_report_service import CatalogReportService
 from library_layer.services.new_releases_service import NewReleasesService
 from library_layer.services.new_releases_service import Window as NewReleasesWindow
 from library_layer.utils.db import get_conn
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 logger = Logger(service="api")
 
@@ -65,6 +66,7 @@ _report_repo = ReportRepository(get_conn)
 _review_repo = ReviewRepository(get_conn)
 _tag_repo = TagRepository(get_conn)
 _waitlist_repo = WaitlistRepository(get_conn)
+_waitlist_suggestion_repo = WaitlistSuggestionRepository(get_conn)
 _matview_repo = MatviewRepository(get_conn)
 _new_releases_repo = NewReleasesRepository(get_conn)
 _new_releases_service = NewReleasesService(_new_releases_repo)
@@ -82,6 +84,11 @@ _genre_synthesis_repo = GenreSynthesisRepository(get_conn)
 
 class WaitlistRequest(BaseModel):
     email: EmailStr
+
+
+class WaitlistSuggestionRequest(BaseModel):
+    email: EmailStr
+    suggestion: str = Field(min_length=1, max_length=2000)
 
 
 class AnalysisRequestBody(BaseModel):
@@ -1028,6 +1035,20 @@ async def join_waitlist(body: WaitlistRequest) -> dict:
         )
 
     return {"status": "registered"}
+
+
+@app.post("/api/waitlist/suggestion")
+async def submit_waitlist_suggestion(body: WaitlistSuggestionRequest) -> dict:
+    """Record a freeform Pro-feature suggestion from a waitlist member."""
+    normalized_email = body.email.strip().lower()
+    suggestion = body.suggestion.strip()
+    if not suggestion:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Suggestion cannot be empty", "code": "empty_suggestion"},
+        )
+    _waitlist_suggestion_repo.add(normalized_email, suggestion)
+    return {"status": "received"}
 
 
 @app.post("/api/chat")

--- a/src/lambda-functions/migrations/0056_waitlist_suggestions.sql
+++ b/src/lambda-functions/migrations/0056_waitlist_suggestions.sql
@@ -1,0 +1,8 @@
+-- depends: 0055_review_count_at_last_fetch
+
+CREATE TABLE IF NOT EXISTS waitlist_suggestions (
+    id          SERIAL PRIMARY KEY,
+    email       TEXT NOT NULL,
+    suggestion  TEXT NOT NULL,
+    created_at  TIMESTAMPTZ DEFAULT NOW()
+);

--- a/src/library-layer/library_layer/repositories/waitlist_suggestion_repo.py
+++ b/src/library-layer/library_layer/repositories/waitlist_suggestion_repo.py
@@ -1,0 +1,24 @@
+"""WaitlistSuggestionRepository — pure SQL I/O for the waitlist_suggestions table."""
+
+from library_layer.repositories.base import BaseRepository
+
+
+class WaitlistSuggestionRepository(BaseRepository):
+    """CRUD operations for the waitlist_suggestions table."""
+
+    def add(self, email: str, suggestion: str) -> None:
+        """Insert a suggestion. Always inserts; multiple per email allowed."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO waitlist_suggestions (email, suggestion)
+                VALUES (%s, %s)
+                """,
+                (email, suggestion),
+            )
+        self.conn.commit()
+
+    def count(self) -> int:
+        """Return total number of suggestion entries."""
+        row = self._fetchone("SELECT COUNT(*) AS n FROM waitlist_suggestions", ())
+        return int(row["n"]) if row else 0

--- a/src/library-layer/library_layer/schema.py
+++ b/src/library-layer/library_layer/schema.py
@@ -464,6 +464,15 @@ TABLES: tuple[str, ...] = (
     "ALTER TABLE games ADD COLUMN IF NOT EXISTS has_early_access_reviews BOOLEAN DEFAULT FALSE",
     # 0055_review_count_at_last_fetch — delta gate for review refetch dispatcher
     "ALTER TABLE app_catalog ADD COLUMN IF NOT EXISTS review_count_at_last_fetch INTEGER NOT NULL DEFAULT 0",
+    # 0056_waitlist_suggestions — optional Pro-feature suggestions captured post-signup
+    """
+    CREATE TABLE IF NOT EXISTS waitlist_suggestions (
+        id          SERIAL PRIMARY KEY,
+        email       TEXT NOT NULL,
+        suggestion  TEXT NOT NULL,
+        created_at  TIMESTAMPTZ DEFAULT NOW()
+    )
+    """,
 )
 
 # Indexes — kept for test suite use only.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,17 @@ class _MemWaitlistRepo:
         return True
 
 
+class _MemWaitlistSuggestionRepo:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str]] = []
+
+    def add(self, email: str, suggestion: str) -> None:
+        self.rows.append((email, suggestion))
+
+    def count(self) -> int:
+        return len(self.rows)
+
+
 class _MemCatalogReportRepo:
     """Stub for CatalogReportRepository — returns empty results by default."""
 
@@ -141,6 +152,7 @@ def reset_api_state() -> None:
     api_module._matview_repo = _MemMatviewRepo()  # type: ignore[assignment]
     api_module._job_repo = _MemJobRepo()  # type: ignore[assignment]
     api_module._waitlist_repo = _MemWaitlistRepo()  # type: ignore[assignment]
+    api_module._waitlist_suggestion_repo = _MemWaitlistSuggestionRepo()  # type: ignore[assignment]
     api_module._catalog_report_repo = _MemCatalogReportRepo()  # type: ignore[assignment]
     api_module._analysis_request_repo = _MemAnalysisRequestRepo()  # type: ignore[assignment]
     api_module._catalog_report_service = CatalogReportService(  # type: ignore[assignment]
@@ -597,6 +609,42 @@ def test_waitlist_rejects_empty_email(client: TestClient) -> None:
     """POST /api/waitlist with an empty string returns 422."""
     resp = client.post("/api/waitlist", json={"email": ""})
     assert resp.status_code == 422
+
+
+def test_waitlist_suggestion_records_payload(client: TestClient) -> None:
+    """POST /api/waitlist/suggestion stores trimmed email and trimmed suggestion."""
+    import lambda_functions.api.handler as api_module
+
+    resp = client.post(
+        "/api/waitlist/suggestion",
+        json={"email": "  Tester@Example.com ", "suggestion": "  weekly genre digest  "},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "received"}
+    repo = api_module._waitlist_suggestion_repo
+    assert repo.count() == 1
+    assert repo.rows[0] == ("tester@example.com", "weekly genre digest")
+
+
+def test_waitlist_suggestion_rejects_empty_text(client: TestClient) -> None:
+    """POST /api/waitlist/suggestion with whitespace-only suggestion returns 400."""
+    resp = client.post(
+        "/api/waitlist/suggestion",
+        json={"email": "user@example.com", "suggestion": "   "},
+    )
+    assert resp.status_code == 400
+
+
+def test_waitlist_suggestion_allows_unknown_email(client: TestClient) -> None:
+    """Suggestion endpoint accepts emails not present in waitlist (soft coupling)."""
+    import lambda_functions.api.handler as api_module
+
+    resp = client.post(
+        "/api/waitlist/suggestion",
+        json={"email": "stranger@example.com", "suggestion": "track competitor sentiment"},
+    )
+    assert resp.status_code == 200
+    assert api_module._waitlist_suggestion_repo.count() == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -627,12 +627,18 @@ def test_waitlist_suggestion_records_payload(client: TestClient) -> None:
 
 
 def test_waitlist_suggestion_rejects_empty_text(client: TestClient) -> None:
-    """POST /api/waitlist/suggestion with whitespace-only suggestion returns 400."""
+    """POST /api/waitlist/suggestion with whitespace-only suggestion returns 400 and records nothing."""
+    import lambda_functions.api.handler as api_module
+
     resp = client.post(
         "/api/waitlist/suggestion",
         json={"email": "user@example.com", "suggestion": "   "},
     )
     assert resp.status_code == 400
+    assert resp.json() == {
+        "detail": {"error": "Suggestion cannot be empty", "code": "empty_suggestion"}
+    }
+    assert api_module._waitlist_suggestion_repo.count() == 0
 
 
 def test_waitlist_suggestion_allows_unknown_email(client: TestClient) -> None:


### PR DESCRIPTION
Carefully check this PR!!  It implements prompt at: scripts/prompts/waitlist-suggestion-capture.md.

- **Schema migration** — new `waitlist_suggestions` table appended to `TABLES` in `src/library-layer/library_layer/schema.py`. Confirm column types (`SERIAL` PK, `TEXT NOT NULL` for both `email` and `suggestion`, `TIMESTAMPTZ DEFAULT NOW()`), and confirm the deliberate choice that `email` is **not** UNIQUE and **not** an FK to `waitlist.email` (soft-coupling so multiple suggestions per email are allowed and a missing waitlist row never rejects a suggestion). Migration is additive (`CREATE TABLE IF NOT EXISTS`) and does not touch the existing `waitlist` table.
- **New endpoint `POST /api/waitlist/suggestion`** — verify the pydantic model uses `Field(min_length=1, max_length=2000)` (so >2000-char payloads return 422), the handler trims+lowercases email, trims suggestion, and returns HTTP 400 `{"error": "Suggestion cannot be empty", "code": "empty_suggestion"}` for whitespace-only input. Endpoint does **not** check that the email exists in `waitlist` (intentional soft coupling).
- **Frontend state machine** — `WaitlistEmailForm.tsx` now transitions `submitting → awaiting_suggestion → (sending_suggestion) → thanked`. Confirm: empty-textarea Send is treated as Skip (no API call), the existing `data-testid="waitlist-success-${variant}"` is preserved on the final thanked block (so Playwright tests still find it), and the new interstitial uses `data-testid="waitlist-suggestion-form-${variant}"`. Both `hero` and `repeat` variants share the flow.
- **Plausible events** — `Waitlist Suggestion` fires with `{ length, variant }` on a real send; `Waitlist Suggestion Skipped` fires with `{ variant }` on Skip or empty Send. `Waitlist Signup` continues to fire as before.
- **Tests** — `tests/test_api.py` adds `_MemWaitlistSuggestionRepo` injected via the existing `reset_api_state` autouse fixture and three tests: records trimmed payload, rejects whitespace-only with 400, allows unknown email (asserts soft-coupling). All run against in-memory mocks, not the live DB.
- **No new dependencies** — `EmailStr` and `Field` come from already-imported `pydantic`. No `poetry lock` re-run needed.
- **Manual smoke not yet run by Claude** — please verify in `npm run dev`: hero + repeat variants both show the interstitial after a successful waitlist submit, `Send` with text inserts a row in `waitlist_suggestions`, `Skip` (and empty Send) inserts no row, already-registered emails still see the interstitial and end on the "You're already on the list." copy.

Full test suite: 706 passed, 0 failed (run from repo root). Frontend `tsc --noEmit` and `npm run build` clean. No frontend `lint` script in `package.json`, so that step was skipped.