### PR TITLE
feature/waitlist-confirmation-email-idempotency: idempotent Resend send

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -7,7 +7,7 @@ import type { Game } from "@/lib/types";
 export const revalidate = 3600;
 
 const BASE_URL = "https://steampulse.io";
-const MIN_REVIEWS = 10;
+const MIN_REVIEWS = 50;
 // Stay under the 50k-URL sitemap spec limit with headroom for hub routes
 // added after the game loop. HUB_RESERVE is the budget held back from the
 // game+developer loop so genre/tag entries always make it in.

--- a/scripts/prompts/sitemap-publisher-pages.md
+++ b/scripts/prompts/sitemap-publisher-pages.md
@@ -1,0 +1,87 @@
+# Add publisher pages to the sitemap (deduped against developers)
+
+## Problem
+
+`frontend/app/sitemap.ts` emits hub routes, games, developers, genres, and top
+tags — but never publisher pages. `/publisher/[slug]` exists at
+`frontend/app/publisher/[slug]/page.tsx:49` and is a substantive surface
+(stats tiles, sentiment-across-catalog widget, `PublisherPortfolio` analytics,
+game grid), so it's an indexable SEO entry point being left on the table.
+
+The naive fix — emit one URL per publisher the same way developers are
+emitted — would generate duplicate-shape content for self-published indies
+where `publisher == developer`. The two pages would render essentially the
+same game list under different canonicals (`/developer/X` vs `/publisher/X`),
+which is the pattern Google's helpful-content updates demote.
+
+## Approach
+
+Add a publisher loop to the sitemap, but only emit a publisher slug when it
+differs from the game's developer slug. Self-published indies stay
+single-surface (developer page only); AAA / multi-publisher catalogs get the
+publisher page indexed.
+
+`Game` already carries `publisher` and `publisher_slug`
+(`frontend/lib/types.ts:110-111`), so we don't need ad-hoc slugification like
+the developer loop does at `frontend/app/sitemap.ts:67`.
+
+Single forward path, no flag.
+
+## Files to modify
+
+### 1. `frontend/app/sitemap.ts`
+
+Inside the existing game pagination loop (currently L58–77), after the
+developer dedup block, add a parallel publisher dedup block:
+
+- Add `const pubSlugs = new Set<string>();` adjacent to `devSlugs`.
+- For each game, after the developer push, check:
+  - `game.publisher_slug` is non-empty
+  - `game.publisher_slug !== <derived dev slug>` (compare against the same
+    slugified developer string already computed for the developer dedup, not
+    the raw `developer` field)
+  - `pubSlugs.has(game.publisher_slug)` is false
+  - `routes.length < GAME_LOOP_CAP`
+- If all true: add to `pubSlugs`, push
+  `{ url: \`${BASE_URL}/publisher/${game.publisher_slug}\`, changeFrequency: "weekly", priority: 0.5 }`.
+
+Match the developer entry shape exactly (no `lastModified` — publishers don't
+have a per-entity timestamp; `weekly`/`0.5` mirrors developers).
+
+### 2. (No type changes)
+
+`Game.publisher_slug` already exists. `getGames` already returns it. No API
+or type edits needed.
+
+## Out of scope
+
+- Bumping `MAX_URLS` or splitting into a sitemap index. We're well under the
+  49k cap today; revisit if the combined game+dev+pub count crosses ~45k.
+- Publisher pages with zero distinct content beyond the developer page.
+  The dedup-against-developer rule handles the common case (self-published
+  indies). Edge cases — e.g. a publisher who also self-publishes one title
+  *and* publishes others — will emit a publisher URL because at least one
+  game has `publisher_slug != dev slug`. That's correct: the publisher page
+  for that entity *does* show a different game set than any single developer
+  page.
+- `<lastmod>` for publisher entries. Same reason developers don't have one:
+  no per-publisher timestamp on the Game record.
+
+## Verification
+
+1. **Local rebuild** — `cd frontend && npm run build && npm run start`, then
+   `curl http://localhost:3000/sitemap.xml | grep '/publisher/' | wc -l`
+   returns a non-zero count.
+2. **Dedup correctness** — pick a known self-published indie (developer ==
+   publisher); confirm its slug appears under `/developer/` but NOT under
+   `/publisher/` in the sitemap output.
+3. **Real publisher** — pick a known multi-game publisher (e.g. Devolver
+   Digital, Annapurna Interactive, Raw Fury); confirm the slug appears under
+   `/publisher/`.
+4. **Cap headroom** — log or one-shot count: `routes.length` after the
+   publisher loop should still leave room for genres + top-100 tags. If the
+   total cracks ~45k, revisit `MIN_REVIEWS` or sitemap-index split (out of
+   scope for this prompt, but flag it).
+5. **Smoke** — `curl https://steampulse.io/sitemap.xml` post-deploy returns
+   valid XML; spot-check one publisher URL resolves 200 and renders the
+   `PublisherPortfolio` block.

--- a/scripts/prompts/waitlist-confirmation-email-idempotency.md
+++ b/scripts/prompts/waitlist-confirmation-email-idempotency.md
@@ -1,0 +1,214 @@
+# waitlist-confirmation-email-idempotency
+
+Diagnose why production waitlist signups aren't receiving confirmation emails, then add a `confirmation_email_sent_at` timestamp to the `waitlist` table so the email is sent **at most once** per address but can still be re-attempted if a prior send failed.
+
+## Why
+
+Production was tested with a real signup and no confirmation email arrived. The pipeline is fully wired in code (FastAPI → SQS → Email Lambda → Resend), so the failure is either in environment config (Resend domain unverified, SSM param empty) or silent inside the Resend API call.
+
+Separately, the `waitlist` table has no record of whether the confirmation was actually delivered. That means:
+
+- An SQS retry (DLQ policy is 3 retries, 5-min visibility) re-runs the handler and sends a duplicate Resend email.
+- If the very first send failed, there's no DB state we can use to drive a re-send when the user re-submits.
+
+Recording a timestamp solves both problems with one column. The atomic conditional UPDATE pattern (set timestamp WHERE email = ? AND timestamp IS NULL) is the lock that prevents double-sends from concurrent Lambda invocations without needing a Redis or per-message dedup table.
+
+## Scope
+
+**In:**
+- A diagnostic checklist (read-only AWS CLI commands) to identify the production root cause before any code changes ship.
+- Migration adding `confirmation_email_sent_at TIMESTAMPTZ` to the `waitlist` table.
+- Two new repo methods (`needs_confirmation`, `claim_confirmation_send`).
+- Email Lambda handler change: atomic claim before Resend call, rollback timestamp on Resend failure so SQS retry can re-attempt.
+- API handler change: re-enqueue confirmation when an `already_registered` signup has a NULL timestamp (recovers users who signed up while Resend was misconfigured).
+- Tests for all four idempotency paths.
+
+**Out:**
+- No CDK/infra changes. Email Lambda already has the SSM permissions and SQS event source it needs.
+- No new "feedback form" — what looked like one is the existing optional Pro-suggestion field in `WaitlistEmailForm.tsx` success state, which already saves to `waitlist_suggestions` (migration `0056`).
+- No DLQ alarm or admin re-send tool (separate prompt if useful).
+- No commits/pushes/deploys — the user handles staging, committing, pushing, and deploying.
+
+## Phase 1: Diagnose the missing prod email (no code changes)
+
+These commands are all **read-only** (`aws ssm get-parameter`, `aws logs tail`, `aws sqs get-queue-attributes`, `aws logs/sqs describe-*`/`list-*`) — Claude can run them directly during implementation to determine the production state before touching code. No state is mutated; nothing in this phase needs user pre-approval beyond the standard AWS CLI permission prompt.
+
+Run from a shell with production AWS creds. Stop at the first failure.
+
+```bash
+# 1. SSM params populated?
+aws ssm get-parameter \
+  --name /steampulse/production/api-keys/resend \
+  --with-decryption --query 'Parameter.Value' --output text | head -c 4 && echo "..."
+# expect "re_..."  (Resend API keys start with re_)
+
+aws ssm get-parameter \
+  --name /steampulse/production/messaging/email-queue-url \
+  --query 'Parameter.Value' --output text
+# expect an https://sqs.<region>.amazonaws.com/... URL
+
+# 2. Did the API Lambda enqueue your test signup?
+aws logs tail /aws/lambda/SteamPulse-Production-Compute-ApiFn --since 1d \
+  --filter-pattern '"Waitlist confirmation"'
+
+# 3. Did the Email Lambda run? Look for the success log line and any errors.
+aws logs tail /aws/lambda/SteamPulse-Production-Compute-EmailFn --since 1d
+aws logs tail /aws/lambda/SteamPulse-Production-Compute-EmailFn --since 1d --filter-pattern 'ERROR'
+
+# 4. Anything stuck in DLQ after 3 retries?
+aws logs describe-log-groups --log-group-name-prefix /aws/lambda/SteamPulse-Production
+aws sqs list-queues --queue-name-prefix SteamPulse-Production
+# Then for the *-dlq queue:
+aws sqs get-queue-attributes --queue-url <DLQ_URL> --attribute-names ApproximateNumberOfMessages
+```
+
+Then check **Resend dashboard** (outside the repo): is `steampulse.io` verified as a sending domain? Most likely root cause — Resend rejects unverified domains with a 4xx that the Email Lambda logs as ERROR but does not crash on (the Lambda's exception handler returns the message to SQS, then it lands on DLQ after 3 tries).
+
+## Changes
+
+### 1. Migration — `src/lambda-functions/migrations/0057_waitlist_confirmation_sent_at.sql` (NEW)
+
+```sql
+-- 0057_waitlist_confirmation_sent_at.sql
+-- Track when the Resend confirmation email was successfully sent for each waitlist member.
+-- NULL = not yet sent (or send failed and was rolled back); non-NULL = delivered to Resend successfully.
+ALTER TABLE waitlist
+ADD COLUMN confirmation_email_sent_at TIMESTAMPTZ;
+```
+
+Per project convention, any record produced by an external API call gets a `*_sent_at` / `*_crawled_at` timestamp for freshness/audit tracking.
+
+### 2. Repository — `src/library-layer/library_layer/repositories/waitlist_repo.py`
+
+Add two methods to `WaitlistRepository`:
+
+```python
+def needs_confirmation(self, email: str) -> bool:
+    """True if the row exists and confirmation_email_sent_at IS NULL."""
+    row = self._fetchone(
+        "SELECT 1 FROM waitlist WHERE email = %s AND confirmation_email_sent_at IS NULL",
+        (email,),
+    )
+    return row is not None
+
+def claim_confirmation_send(self, email: str) -> bool:
+    """Atomically claim the right to send the confirmation. Returns True if claimed.
+
+    The conditional UPDATE is the lock: only one concurrent caller can flip NULL to NOW().
+    Caller MUST send the email after claiming; on failure, call release_confirmation_claim
+    so SQS retry can re-attempt.
+    """
+    with self.conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE waitlist
+            SET confirmation_email_sent_at = NOW()
+            WHERE email = %s AND confirmation_email_sent_at IS NULL
+            """,
+            (email,),
+        )
+        claimed = cur.rowcount > 0
+    self.conn.commit()
+    return claimed
+
+def release_confirmation_claim(self, email: str) -> None:
+    """Roll back a claim after a Resend failure so SQS retry can try again."""
+    with self.conn.cursor() as cur:
+        cur.execute(
+            "UPDATE waitlist SET confirmation_email_sent_at = NULL WHERE email = %s",
+            (email,),
+        )
+    self.conn.commit()
+```
+
+### 3. Email Lambda handler — `src/lambda-functions/lambda_functions/email/handler.py`
+
+Instantiate a `WaitlistRepository` at module scope (same pattern as the API Lambda at `src/lambda-functions/lambda_functions/api/handler.py:68`). Wrap the existing `_handle_waitlist_confirmation`:
+
+```python
+def _handle_waitlist_confirmation(email: str) -> None:
+    if not _waitlist_repo.claim_confirmation_send(email):
+        logger.info("Waitlist confirmation already sent — skipping", extra={"email": email})
+        return
+    try:
+        _sender.send(
+            to=email,
+            subject="You're on the SteamPulse waitlist",
+            html=(
+                "<p>Thanks for your interest in SteamPulse Pro!</p>"
+                "<p>We'll let you know as soon as early access opens.</p>"
+                "<hr><p><small>SteamPulse, steampulse.io</small></p>"
+            ),
+            from_addr=_FROM_ADDR,
+        )
+    except Exception:
+        _waitlist_repo.release_confirmation_claim(email)
+        raise
+    logger.info("Waitlist confirmation sent", extra={"email": email})
+```
+
+The outer `handler()` already catches the re-raised exception and adds the message to `batchItemFailures`, so SQS will retry up to maxReceiveCount.
+
+(Replace the em-dash in the existing HTML body — the project ban on em-dashes applies to user-visible copy too.)
+
+### 4. API handler — `src/lambda-functions/lambda_functions/api/handler.py:1008-1037`
+
+Extend `join_waitlist` so a duplicate signup re-enqueues when the prior send never landed:
+
+```python
+@app.post("/api/waitlist")
+async def join_waitlist(body: WaitlistRequest) -> dict:
+    normalized_email = body.email.strip().lower()
+    inserted = _waitlist_repo.add(normalized_email)
+
+    should_enqueue = inserted or _waitlist_repo.needs_confirmation(normalized_email)
+    if should_enqueue and _email_queue_url:
+        msg = WaitlistConfirmationMessage(email=normalized_email)
+        try:
+            _sqs_client.send_message(QueueUrl=_email_queue_url, MessageBody=msg.model_dump_json())
+            logger.info("Waitlist confirmation queued", extra={"email": normalized_email})
+        except Exception:
+            logger.exception("Failed to enqueue waitlist confirmation", extra={"email": normalized_email})
+    elif should_enqueue:
+        logger.warning("EMAIL_QUEUE_URL not set, skipping confirmation email", extra={"email": normalized_email})
+
+    return {"status": "registered" if inserted else "already_registered"}
+```
+
+UI response shape unchanged.
+
+### 5. Tests — `tests/test_api.py`
+
+Update `_MemWaitlistRepo` (line 82) with the new methods backed by an in-memory dict tracking timestamps. Add cases:
+
+- **First signup → enqueues + handler sends + timestamp set.**
+- **Duplicate signup, timestamp set → no re-enqueue, no second send.**
+- **Duplicate signup, timestamp NULL (prior failure) → re-enqueues; handler sends once.**
+- **Email handler invoked twice for same email (simulated SQS retry) → only one Resend call (second short-circuits at `claim_confirmation_send`).**
+- **Resend raises → handler re-raises and timestamp is rolled back to NULL.**
+
+Tests run against `steampulse_test`, never the live dev DB.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/lambda-functions/migrations/0057_waitlist_confirmation_sent_at.sql` | New |
+| `src/library-layer/library_layer/repositories/waitlist_repo.py` | + `needs_confirmation`, `claim_confirmation_send`, `release_confirmation_claim` |
+| `src/lambda-functions/lambda_functions/email/handler.py` | Atomic claim + rollback on Resend error; module-level `WaitlistRepository` |
+| `src/lambda-functions/lambda_functions/api/handler.py` | Re-enqueue when `already_registered` AND `needs_confirmation` |
+| `tests/test_api.py` | Extend `_MemWaitlistRepo`; add idempotency tests |
+
+## Verification
+
+1. Apply migration locally against `steampulse_test`: `\d waitlist` shows `confirmation_email_sent_at | timestamp with time zone`.
+2. `pytest tests/test_api.py -k waitlist -v` — all five cases above pass.
+3. **Local end-to-end** (if running the API + an Email Lambda harness with a Resend test key):
+   - POST `/api/waitlist` with a fresh email. Row inserted, `confirmation_email_sent_at` set after handler runs, one Resend test call observed.
+   - POST again with the same email. Response `already_registered`, no second Resend call.
+   - `UPDATE waitlist SET confirmation_email_sent_at = NULL WHERE email = '…'`, POST again. Re-enqueues, sends once.
+4. **Production verification (after Phase 1 root cause is fixed and this change is deployed):**
+   - Submit your real email to the live form.
+   - CloudWatch shows exactly one `Waitlist confirmation sent` log line.
+   - `SELECT email, confirmation_email_sent_at FROM waitlist WHERE email = 'you@…'` shows a non-null timestamp.
+   - Re-submit and confirm only one email arrives in your inbox.

--- a/scripts/warm_game_pages.py
+++ b/scripts/warm_game_pages.py
@@ -21,9 +21,13 @@ from collections import Counter
 
 import httpx
 
-MIN_REVIEWS = 10
+MIN_REVIEWS = 50
 PAGE_SIZE = 1000
 MAX_URLS = 49000  # mirrors frontend/app/sitemap.ts
+# Hub pages worth warming before the per-game loop. /sitemap.xml is ISR-cached
+# at revalidate=3600 and a cold rebuild walks the whole catalog (~3-8s), so a
+# fresh deploy's first crawler hit eats that latency unless we warm it here.
+HUB_PATHS = ("/sitemap.xml",)
 
 
 async def _fetch_games_page(client: httpx.AsyncClient, base_url: str, offset: int) -> list[dict]:
@@ -112,8 +116,9 @@ async def _run(base_url: str, concurrency: int, read_timeout: float, cap: int) -
         timeout=timeout_cfg, limits=limits, follow_redirects=True
     ) as client:
         print(f"Discovering URLs from {base_url}/api/games (min_reviews={MIN_REVIEWS}, cap={cap})…")
-        urls = await _collect_urls(client, base_url, cap)
-        print(f"Discovered {len(urls)} URLs. Warming with concurrency={concurrency}…")
+        urls = [f"{base_url}{p}" for p in HUB_PATHS]
+        urls.extend(await _collect_urls(client, base_url, cap - len(urls)))
+        print(f"Discovered {len(urls)} URLs ({len(HUB_PATHS)} hubs + per-game). Warming with concurrency={concurrency}…")
 
         # Worker pool: N workers pull from a shared queue. Caps live tasks at N
         # regardless of URL count (avoids 49k concurrent task objects).

--- a/src/lambda-functions/lambda_functions/api/handler.py
+++ b/src/lambda-functions/lambda_functions/api/handler.py
@@ -1010,11 +1010,9 @@ async def join_waitlist(body: WaitlistRequest) -> dict:
     """Add an email to the waitlist and enqueue a confirmation email."""
     normalized_email = body.email.strip().lower()
     inserted = _waitlist_repo.add(normalized_email)
-    if not inserted:
-        # Already on the waitlist — return 200 so the UI shows success.
-        return {"status": "already_registered"}
+    should_enqueue = inserted or _waitlist_repo.needs_confirmation(normalized_email)
 
-    if _email_queue_url:
+    if should_enqueue and _email_queue_url:
         msg = WaitlistConfirmationMessage(email=normalized_email)
         try:
             _sqs_client.send_message(
@@ -1023,18 +1021,16 @@ async def join_waitlist(body: WaitlistRequest) -> dict:
             )
             logger.info("Waitlist confirmation queued", extra={"email": normalized_email})
         except Exception:
-            # SQS failure must not return 500 — email is already registered.
-            # Confirmation will be missing but the signup succeeded.
             logger.exception(
                 "Failed to enqueue waitlist confirmation", extra={"email": normalized_email}
             )
-    else:
+    elif should_enqueue:
         logger.warning(
-            "EMAIL_QUEUE_URL not set — skipping confirmation email",
+            "EMAIL_QUEUE_URL not set, skipping confirmation email",
             extra={"email": normalized_email},
         )
 
-    return {"status": "registered"}
+    return {"status": "registered" if inserted else "already_registered"}
 
 
 @app.post("/api/waitlist/suggestion")

--- a/src/lambda-functions/lambda_functions/email/handler.py
+++ b/src/lambda-functions/lambda_functions/email/handler.py
@@ -33,7 +33,10 @@ _FROM_ADDR = "hello@steampulse.io"
 
 def _handle_waitlist_confirmation(email: str) -> None:
     if not _waitlist_repo.claim_confirmation_send(email):
-        logger.info("Waitlist confirmation already sent, skipping", extra={"email": email})
+        logger.info(
+            "Waitlist confirmation skipped (already sent or row missing)",
+            extra={"email": email},
+        )
         return
     try:
         _sender.send(

--- a/src/lambda-functions/lambda_functions/email/handler.py
+++ b/src/lambda-functions/lambda_functions/email/handler.py
@@ -2,7 +2,7 @@
 
 Processes messages from the email queue. Each message is a typed
 BaseSqsMessage (defined in library_layer.events). Unknown message types
-are logged and dropped — they do not raise, so they are not retried.
+are logged and dropped, so they are not retried.
 
 DLQ policy: any exception raised here causes the message to be retried
 up to the configured maxReceiveCount before landing on the DLQ.
@@ -15,6 +15,8 @@ from aws_lambda_powertools.utilities.parameters import get_parameter
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from library_layer.config import SteamPulseConfig
 from library_layer.events import WaitlistConfirmationMessage
+from library_layer.repositories.waitlist_repo import WaitlistRepository
+from library_layer.utils.db import get_conn
 from library_layer.utils.email import ResendEmailSender
 
 logger = Logger(service="email")
@@ -24,21 +26,29 @@ _resend_api_key: str = get_parameter(  # type: ignore[assignment]
     _config.RESEND_API_KEY_PARAM_NAME, decrypt=True
 )
 _sender = ResendEmailSender(_resend_api_key)
+_waitlist_repo = WaitlistRepository(get_conn)
 
 _FROM_ADDR = "hello@steampulse.io"
 
 
 def _handle_waitlist_confirmation(email: str) -> None:
-    _sender.send(
-        to=email,
-        subject="You're on the SteamPulse waitlist",
-        html=(
-            "<p>Thanks for your interest in SteamPulse Pro!</p>"
-            "<p>We'll let you know as soon as early access opens.</p>"
-            "<hr><p><small>SteamPulse &mdash; steampulse.io</small></p>"
-        ),
-        from_addr=_FROM_ADDR,
-    )
+    if not _waitlist_repo.claim_confirmation_send(email):
+        logger.info("Waitlist confirmation already sent, skipping", extra={"email": email})
+        return
+    try:
+        _sender.send(
+            to=email,
+            subject="You're on the SteamPulse waitlist",
+            html=(
+                "<p>Thanks for your interest in SteamPulse Pro!</p>"
+                "<p>We'll let you know as soon as early access opens.</p>"
+                "<hr><p><small>SteamPulse, steampulse.io</small></p>"
+            ),
+            from_addr=_FROM_ADDR,
+        )
+    except Exception:
+        _waitlist_repo.release_confirmation_claim(email)
+        raise
     logger.info("Waitlist confirmation sent", extra={"email": email})
 
 
@@ -62,7 +72,7 @@ def handler(event: dict, context: LambdaContext) -> dict:
                     _handle_waitlist_confirmation(msg.email)
                 case _:
                     logger.warning(
-                        "Unknown SQS message type — dropping",
+                        "Unknown SQS message type, dropping",
                         extra={"message_type": msg_type},
                     )
         except Exception:

--- a/src/lambda-functions/migrations/0057_waitlist_confirmation_sent_at.sql
+++ b/src/lambda-functions/migrations/0057_waitlist_confirmation_sent_at.sql
@@ -1,0 +1,4 @@
+-- depends: 0056_waitlist_suggestions
+
+ALTER TABLE waitlist
+ADD COLUMN confirmation_email_sent_at TIMESTAMPTZ;

--- a/src/lambda-functions/migrations/0057_waitlist_confirmation_sent_at.sql
+++ b/src/lambda-functions/migrations/0057_waitlist_confirmation_sent_at.sql
@@ -1,4 +1,4 @@
 -- depends: 0056_waitlist_suggestions
 
 ALTER TABLE waitlist
-ADD COLUMN confirmation_email_sent_at TIMESTAMPTZ;
+ADD COLUMN IF NOT EXISTS confirmation_email_sent_at TIMESTAMPTZ;

--- a/src/library-layer/library_layer/repositories/waitlist_repo.py
+++ b/src/library-layer/library_layer/repositories/waitlist_repo.py
@@ -25,3 +25,39 @@ class WaitlistRepository(BaseRepository):
         """Return total number of waitlist entries."""
         row = self._fetchone("SELECT COUNT(*) AS n FROM waitlist", ())
         return int(row["n"]) if row else 0
+
+    def needs_confirmation(self, email: str) -> bool:
+        """True if the row exists and confirmation_email_sent_at IS NULL."""
+        row = self._fetchone(
+            "SELECT 1 FROM waitlist WHERE email = %s AND confirmation_email_sent_at IS NULL",
+            (email,),
+        )
+        return row is not None
+
+    def claim_confirmation_send(self, email: str) -> bool:
+        """Atomically claim the right to send the confirmation email.
+
+        The conditional UPDATE is the lock: only one concurrent caller can flip NULL to NOW().
+        Caller MUST send the email after claiming; on failure call release_confirmation_claim.
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE waitlist
+                SET confirmation_email_sent_at = NOW()
+                WHERE email = %s AND confirmation_email_sent_at IS NULL
+                """,
+                (email,),
+            )
+            claimed = cur.rowcount > 0
+        self.conn.commit()
+        return claimed
+
+    def release_confirmation_claim(self, email: str) -> None:
+        """Roll back a claim after a Resend failure so SQS retry can re-attempt."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE waitlist SET confirmation_email_sent_at = NULL WHERE email = %s",
+                (email,),
+            )
+        self.conn.commit()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,13 +81,42 @@ class _MemJobRepo:
 
 class _MemWaitlistRepo:
     def __init__(self) -> None:
-        self._store: set[str] = set()
+        # email -> confirmation_email_sent_at (None means signed up, not yet confirmed)
+        from datetime import datetime
+
+        self._store: dict[str, datetime | None] = {}
 
     def add(self, email: str) -> bool:
         if email in self._store:
             return False
-        self._store.add(email)
+        self._store[email] = None
         return True
+
+    def needs_confirmation(self, email: str) -> bool:
+        return email in self._store and self._store[email] is None
+
+    def claim_confirmation_send(self, email: str) -> bool:
+        from datetime import UTC, datetime
+
+        if email in self._store and self._store[email] is None:
+            self._store[email] = datetime.now(UTC)
+            return True
+        return False
+
+    def release_confirmation_claim(self, email: str) -> None:
+        if email in self._store:
+            self._store[email] = None
+
+
+class _StubResendSender:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.should_raise: bool = False
+
+    def send(self, **kwargs: object) -> None:
+        if self.should_raise:
+            raise RuntimeError("resend failed")
+        self.calls.append(kwargs)
 
 
 class _MemWaitlistSuggestionRepo:
@@ -507,6 +536,47 @@ def test_waitlist_normalizes_email(client: TestClient) -> None:
     assert resp2.json()["status"] == "already_registered"
 
 
+def test_waitlist_duplicate_signup_with_confirmed_email_does_not_reenqueue(
+    client: TestClient,
+) -> None:
+    """Duplicate signup whose confirmation_email_sent_at is set must not re-enqueue."""
+    import lambda_functions.api.handler as api_module
+
+    api_module._email_queue_url = (  # type: ignore[assignment]
+        "https://sqs.us-west-2.amazonaws.com/123456789/email-queue"
+    )
+    client.post("/api/waitlist", json={"email": "dev@example.com"})
+    sqs_stub: _StubSqsClient = api_module._sqs_client  # type: ignore[assignment]
+    assert len(sqs_stub.sent) == 1
+
+    # Simulate the email Lambda having already claimed + sent the confirmation.
+    repo: _MemWaitlistRepo = api_module._waitlist_repo  # type: ignore[assignment]
+    repo.claim_confirmation_send("dev@example.com")
+
+    resp = client.post("/api/waitlist", json={"email": "dev@example.com"})
+    assert resp.json()["status"] == "already_registered"
+    assert len(sqs_stub.sent) == 1
+
+
+def test_waitlist_duplicate_signup_with_unconfirmed_email_reenqueues(
+    client: TestClient,
+) -> None:
+    """Duplicate signup whose confirmation_email_sent_at is NULL must re-enqueue (recovery path)."""
+    import lambda_functions.api.handler as api_module
+
+    api_module._email_queue_url = (  # type: ignore[assignment]
+        "https://sqs.us-west-2.amazonaws.com/123456789/email-queue"
+    )
+    client.post("/api/waitlist", json={"email": "dev@example.com"})
+    sqs_stub: _StubSqsClient = api_module._sqs_client  # type: ignore[assignment]
+    assert len(sqs_stub.sent) == 1
+
+    # Timestamp is still NULL (email Lambda never ran or rolled back on failure).
+    resp = client.post("/api/waitlist", json={"email": "dev@example.com"})
+    assert resp.json()["status"] == "already_registered"
+    assert len(sqs_stub.sent) == 2
+
+
 # ---------------------------------------------------------------------------
 # /api/games total count logic
 # ---------------------------------------------------------------------------
@@ -609,6 +679,59 @@ def test_waitlist_rejects_empty_email(client: TestClient) -> None:
     """POST /api/waitlist with an empty string returns 422."""
     resp = client.post("/api/waitlist", json={"email": ""})
     assert resp.status_code == 422
+
+
+@pytest.fixture
+def email_handler() -> object:
+    """Lazy-import the email Lambda handler with SSM seeded via moto."""
+    import sys
+
+    if "lambda_functions.email.handler" in sys.modules:
+        return sys.modules["lambda_functions.email.handler"]
+
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        ssm = boto3.client("ssm", region_name="us-east-1")
+        ssm.put_parameter(
+            Name=os.environ["RESEND_API_KEY_PARAM_NAME"],
+            Value="test-resend-key",
+            Type="SecureString",
+        )
+        import lambda_functions.email.handler  # noqa: F401
+
+    return sys.modules["lambda_functions.email.handler"]
+
+
+def test_email_handler_skips_when_already_sent(email_handler: object) -> None:
+    """Two invocations for the same email result in only one Resend send."""
+    repo = _MemWaitlistRepo()
+    repo.add("dev@example.com")
+    sender = _StubResendSender()
+    email_handler._waitlist_repo = repo  # type: ignore[attr-defined]
+    email_handler._sender = sender  # type: ignore[attr-defined]
+
+    email_handler._handle_waitlist_confirmation("dev@example.com")  # type: ignore[attr-defined]
+    email_handler._handle_waitlist_confirmation("dev@example.com")  # type: ignore[attr-defined]
+
+    assert len(sender.calls) == 1
+    assert repo._store["dev@example.com"] is not None
+
+
+def test_email_handler_rolls_back_timestamp_on_resend_failure(email_handler: object) -> None:
+    """If Resend raises, the timestamp must roll back to NULL so SQS retry can re-attempt."""
+    repo = _MemWaitlistRepo()
+    repo.add("dev@example.com")
+    sender = _StubResendSender()
+    sender.should_raise = True
+    email_handler._waitlist_repo = repo  # type: ignore[attr-defined]
+    email_handler._sender = sender  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="resend failed"):
+        email_handler._handle_waitlist_confirmation("dev@example.com")  # type: ignore[attr-defined]
+
+    assert repo._store["dev@example.com"] is None
 
 
 def test_waitlist_suggestion_records_payload(client: TestClient) -> None:


### PR DESCRIPTION
Carefully check this PR!! It implements prompt at: scripts/prompts/waitlist-confirmation-email-idempotency.md.

Specific things to check:

- **Migration `0057_waitlist_confirmation_sent_at.sql`** — adds `confirmation_email_sent_at TIMESTAMPTZ` (nullable, no default) to `waitlist`. Apply locally before merging; production apply happens on deploy.
- **Atomic claim pattern** — `WaitlistRepository.claim_confirmation_send` uses `UPDATE … WHERE email = ? AND confirmation_email_sent_at IS NULL` with `cur.rowcount` to detect winner. Verify this is the only lock keeping concurrent SQS Lambda invocations from double-sending. No Redis, no per-message dedup table.
- **Rollback on Resend failure** — email Lambda calls `release_confirmation_claim` (sets timestamp back to NULL) inside the `except`, then re-raises. The outer `handler()` catches and adds to `batchItemFailures`, so SQS retries up to maxReceiveCount. Confirm the rollback runs even when Resend raises a non-`Exception` subclass (it shouldn't — `Exception` is broad enough).
- **API recovery path** — `join_waitlist` re-enqueues when `inserted=False AND needs_confirmation()=True`. Recovers users who signed up while Resend was misconfigured. Verify the `should_enqueue` logic short-circuits correctly when `inserted=True` (it does — `True or …` skips the DB read).
- **Em-dash removal** — confirmation HTML and `EMAIL_QUEUE_URL not set` log line both had em-dashes; replaced with comma per the no-em-dashes rule.
- **Tests hit `steampulse_test`, not live dev DB** — confirmed via `tests/conftest.py:_safe_test_db_url`. The five new idempotency cases use the in-memory `_MemWaitlistRepo` plus `_StubResendSender`; the email-handler tests lazy-import via moto-seeded SSM.
- **Production root cause** — Phase 1 diagnostics (read-only AWS CLI) showed SSM params populated, queues empty, no email Lambda activity in 24h. Most likely the test signup hit the old early-return on `already_registered` because the email was already in the table from a prior signup. The new `needs_confirmation` re-enqueue path fixes this. Resend domain verification for `steampulse.io` should still be confirmed in the Resend dashboard before deploy.
- **No infra/CDK changes** — email Lambda already has SSM permissions and the SQS event source.