### PR TITLE
feature/www-to-apex-redirect: redirect www to apex via CloudFront Function

### DIFF
--- a/infra/stacks/delivery_stack.py
+++ b/infra/stacks/delivery_stack.py
@@ -18,7 +18,6 @@ import aws_cdk.aws_route53_targets as route53_targets
 import aws_cdk.aws_s3 as s3
 import aws_cdk.aws_ssm as ssm
 from constructs import Construct
-
 from library_layer.config import SteamPulseConfig
 
 DOMAIN = "steampulse.io"
@@ -116,6 +115,43 @@ class DeliveryStack(cdk.Stack):
             query_string_behavior=cloudfront.CacheQueryStringBehavior.allow_list("limit"),
         )
 
+        # ── www → apex 301 (production only) ─────────────────────────────────
+        # CloudFront Function runs at viewer-request on every behavior so any
+        # www.steampulse.io hit returns a 301 to the apex with path+querystring
+        # preserved. Apex requests pass through unchanged.
+        www_to_apex_fa = (
+            [
+                cloudfront.FunctionAssociation(
+                    function=cloudfront.Function(
+                        self,
+                        "WwwToApexRedirect",
+                        code=cloudfront.FunctionCode.from_inline(
+                            """
+function handler(event) {
+  var request = event.request;
+  var host = request.headers.host && request.headers.host.value;
+  if (host !== 'www.steampulse.io') return request;
+  var qs = '';
+  for (var k in request.querystring) {
+    qs += (qs ? '&' : '?') + k + '=' + request.querystring[k].value;
+  }
+  return {
+    statusCode: 301,
+    statusDescription: 'Moved Permanently',
+    headers: { location: { value: 'https://steampulse.io' + request.uri + qs } }
+  };
+}
+"""
+                        ),
+                        runtime=cloudfront.FunctionRuntime.JS_2_0,
+                    ),
+                    event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
+                )
+            ]
+            if config.is_production
+            else None
+        )
+
         # ── CloudFront ────────────────────────────────────────────────────────
         # Single shared origin per Lambda — reused across all behaviors so the
         # distribution doesn't end up with N copies of the same origin config.
@@ -134,6 +170,7 @@ class DeliveryStack(cdk.Stack):
             cache_policy=api_cache_policy,
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+            function_associations=www_to_apex_fa,
         )
 
         distribution = cloudfront.Distribution(
@@ -145,6 +182,7 @@ class DeliveryStack(cdk.Stack):
                 cache_policy=html_cache_policy,
                 origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
                 allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+                function_associations=www_to_apex_fa,
             ),
             additional_behaviors={
                 "/api/games/*/report": api_cached_behavior,
@@ -157,16 +195,19 @@ class DeliveryStack(cdk.Stack):
                     cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
                     origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
                     allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+                    function_associations=www_to_apex_fa,
                 ),
                 "/_next/static/*": cloudfront.BehaviorOptions(
                     origin=s3_origin,
                     viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                     cache_policy=static_cache_policy,
+                    function_associations=www_to_apex_fa,
                 ),
                 "/static/*": cloudfront.BehaviorOptions(
                     origin=s3_origin,
                     viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                     cache_policy=static_cache_policy,
+                    function_associations=www_to_apex_fa,
                 ),
             },
             domain_names=[DOMAIN, f"www.{DOMAIN}"] if config.is_production else None,

--- a/scripts/prompts/www-to-apex-redirect.md
+++ b/scripts/prompts/www-to-apex-redirect.md
@@ -1,0 +1,140 @@
+# Add www → apex 301 redirect via CloudFront Function
+
+## Problem
+
+Both `https://steampulse.io/<path>` and `https://www.steampulse.io/<path>`
+currently serve the same content directly from the same CloudFront
+distribution (`infra/stacks/delivery_stack.py:172`). Apex is the canonical
+form — `frontend/app/sitemap.ts:9` sets `BASE_URL = "https://steampulse.io"`,
+JSON-LD canonicals in `frontend/app/layout.tsx` use the apex, and per-page
+`alternates.canonical` on game/publisher/developer pages all use apex.
+
+Without a real 301 from www → apex, link signals split between two URLs
+and the canonical hint alone leaks PageRank. Fix it at the CDN edge so the
+redirect is fast (no Lambda invocation) and applies regardless of path.
+
+## Approach
+
+Add a **CloudFront Function** (viewer-request event type) that inspects the
+`Host` header and 301-redirects any `www.steampulse.io` request to the apex
+equivalent. Path and querystring are preserved.
+
+Why a CloudFront Function (not Lambda@Edge, not Next.js middleware):
+- Runs at the edge in <1ms; no cold start, no Lambda billing
+- Doesn't require the request to reach the origin (Next.js Lambda)
+- Already supported in the existing distribution — single CDK construct add
+
+The function attaches to **every behavior** on the distribution (default
+behavior + the `/_next/static/*` and `/static/*` path patterns). Otherwise
+a request to `https://www.steampulse.io/_next/static/foo.js` would still
+serve the static asset directly without redirecting, defeating the purpose.
+
+Single forward path, no flag.
+
+## Files to modify
+
+### 1. `infra/stacks/delivery_stack.py`
+
+Just before the `distribution = cloudfront.Distribution(...)` block (around
+the existing CloudFront construction site near L150-176), add:
+
+```python
+www_to_apex_fn = cloudfront.Function(
+    self,
+    "WwwToApexRedirect",
+    code=cloudfront.FunctionCode.from_inline(
+        """
+function handler(event) {
+  var request = event.request;
+  var host = request.headers.host && request.headers.host.value;
+  if (host !== 'www.steampulse.io') {
+    return request;
+  }
+  var qs = '';
+  for (var key in request.querystring) {
+    qs += (qs ? '&' : '?') + key + '=' + request.querystring[key].value;
+  }
+  return {
+    statusCode: 301,
+    statusDescription: 'Moved Permanently',
+    headers: {
+      location: { value: 'https://steampulse.io' + request.uri + qs }
+    }
+  };
+}
+"""
+    ),
+    runtime=cloudfront.FunctionRuntime.JS_2_0,
+)
+```
+
+Then attach it to **the default behavior and each additional behavior**.
+For each `BehaviorOptions(...)` constructor (default + the two path-pattern
+entries at L166-170 for `/_next/static/*` and `/static/*`), add the kwarg:
+
+```python
+function_associations=[
+    cloudfront.FunctionAssociation(
+        function=www_to_apex_fn,
+        event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
+    ),
+],
+```
+
+Apex hostname `steampulse.io` is hardcoded inside the function body — fine
+because the JS runs on this distribution only and the redirect target is
+domain-specific. If a future env needs a different apex, the function code
+becomes a small Python f-string interpolation against `DOMAIN`.
+
+### 2. (No frontend or DNS changes)
+
+The CloudFront alternate domain names list (`domain_names=[DOMAIN, f"www.{DOMAIN}"]`
+at L172) stays as-is — CloudFront still needs to *accept* www requests at
+the edge so the Function can run on them and emit the 301. Removing www from
+`domain_names` would cause CloudFront to reject www requests with an SSL
+error before the Function ever runs.
+
+The Route 53 `WwwRecord` (L196-204) also stays — it points www at
+CloudFront so the request reaches the edge in the first place.
+
+## Out of scope
+
+- Apex → www direction (we picked apex as canonical; not flipping it).
+- HSTS / strict-transport-security headers. Already covered by Next.js
+  config (`frontend/next.config.ts:22-32`) on responses; not affected by
+  this change.
+- Status-code redirects between trailing-slash variants. Out of scope —
+  Next.js handles this at the app layer.
+
+## Verification
+
+1. **CDK diff** — `cd infra && npx cdk diff SteamPulseDeliveryStack`. Should
+   show one new `AWS::CloudFront::Function` resource and three function
+   association additions on the existing distribution. No distribution
+   recreation.
+2. **Deploy**, then:
+   ```bash
+   curl -I https://www.steampulse.io/
+   ```
+   Expect `HTTP/2 301` with `location: https://steampulse.io/`.
+3. **Path preservation**:
+   ```bash
+   curl -I https://www.steampulse.io/games/440/team-fortress-2
+   ```
+   Expect 301 with `location: https://steampulse.io/games/440/team-fortress-2`.
+4. **Querystring preservation**:
+   ```bash
+   curl -I 'https://www.steampulse.io/search?q=balatro'
+   ```
+   Expect 301 with `location: https://steampulse.io/search?q=balatro`.
+5. **Apex unchanged**:
+   ```bash
+   curl -I https://steampulse.io/
+   ```
+   Expect `HTTP/2 200` (no redirect loop).
+6. **Static asset path** (proves the function is attached to non-default
+   behaviors):
+   ```bash
+   curl -I https://www.steampulse.io/_next/static/some-asset.js
+   ```
+   Expect 301, not 200.


### PR DESCRIPTION
Carefully check this PR!! It implements prompt at: scripts/prompts/www-to-apex-redirect.md.

Specific things to check:

- **CloudFront Function code (`infra/stacks/delivery_stack.py:119-153`)**: the inline JS handler — verify it correctly extracts `Host` from headers, only acts on `www.steampulse.io`, and reconstructs the querystring. Multi-value query keys (rare, e.g. `?tag=a&tag=b`) take only the first value — acceptable for this use case but worth flagging.
- **Apex hostname is hardcoded** in the JS (`'https://steampulse.io'` and `'www.steampulse.io'`). If a future env needs a different apex, the body would need an f-string interpolation against `DOMAIN`. Currently scoped to production only via `if config.is_production`.
- **Function attached to all 5 behaviors**: `default_behavior`, the shared `api_cached_behavior` (covers 4 SSR-fanout paths), `/api/*`, `/_next/static/*`, `/static/*`. If any behavior were missed, www requests on that path would silently bypass the redirect.
- **No distribution recreation in CDK diff**: run `cd infra && npx cdk diff SteamPulseDeliveryStack` before merging — should show exactly 1 new `AWS::CloudFront::Function` resource and 5 behavior `FunctionAssociations` deltas. Anything else (cert change, distribution replacement) means stop.
- **Production gating**: `www_to_apex_fa = [...] if config.is_production else None`. Staging doesn't allocate the Function and the kwarg becomes `None` (CDK accepts that). Verify staging synth still works.
- **`domain_names` and `WwwRecord` intentionally unchanged**: CloudFront still needs www in `domain_names` so it accepts the SSL handshake before the Function can run, and Route53 still needs the www A-record so the request reaches the edge in the first place.

**Drive-by fix**: removed one blank line between two import groups (`from constructs ...` / `from library_layer ...`) in the same file to clear a pre-existing ruff I001 error. Pre-dates this PR — confirmed via stash test against `main`.

**Post-deploy verification** (not blocking review, run after merge):

\`\`\`bash
curl -I https://www.steampulse.io/                            # expect 301 → https://steampulse.io/
curl -I https://www.steampulse.io/games/440/team-fortress-2   # expect 301 with full path
curl -I 'https://www.steampulse.io/search?q=balatro'          # expect 301 with querystring
curl -I https://steampulse.io/                                # expect 200, no loop
curl -I https://www.steampulse.io/_next/static/some-asset.js  # expect 301 (proves attached to non-default behavior)
\`\`\`