### PR TITLE
feature/revalidate-frontend-discover-inner-build-id: discover OpenNext inner build id at cold start

### DIFF
--- a/infra/stacks/compute_stack.py
+++ b/infra/stacks/compute_stack.py
@@ -1008,6 +1008,15 @@ class ComputeStack(cdk.Stack):
                 resources=[f"{frontend_bucket.bucket_arn}/cache/*"],
             )
         )
+        # ListBucket scoped to cache/* so cold-start can discover the OpenNext
+        # inner BUILD_ID via list_objects_v2(Delimiter="/").
+        revalidate_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["s3:ListBucket"],
+                resources=[frontend_bucket.bucket_arn],
+                conditions={"StringLike": {"s3:prefix": ["cache/*"]}},
+            )
+        )
         # CloudFront edge invalidation — distribution ID is resolved at runtime
         # so the resource ARN must be wildcarded.
         revalidate_role.add_to_policy(

--- a/scripts/prompts/api-cache-ttl-bump-plan.md
+++ b/scripts/prompts/api-cache-ttl-bump-plan.md
@@ -1,0 +1,63 @@
+# Plan: api-cache-ttl-bump
+
+## Context
+
+The four `/api/games/{appid}/*` SSR-fanout endpoints (`report`, `review-stats`, `benchmarks`, `related-analyzed`) currently emit `s-maxage=86400, stale-while-revalidate=604800`. CloudFront serves them from the edge for 24h, then the next visitor in any POP forces a Lambda + Postgres hit. The 24h ceiling predates the analysis-pipeline-driven CloudFront invalidation in `revalidate_frontend/handler.py:120-143`, which already busts these exact paths whenever a `ReportReadyEvent` fires. Bumping `s-maxage` to 7d (and SWR to 30d) cuts cold-revalidation Lambda invocations on these endpoints by ~7x with no behavior change, since the freshness signal is push-based, not TTL-based.
+
+Verified in production today (2026-04-30): `cache-control: s-maxage=86400, stale-while-revalidate=604800` and `x-cache: Hit from cloudfront` both present, confirming the cache layer behaves as intended.
+
+## Change
+
+Single file, single constant, plus the comment above it.
+
+### `src/lambda-functions/lambda_functions/api/handler.py:54-56`
+
+Replace:
+
+```python
+# Edge-cache header for the four SSR-fanout endpoints feeding /games/{appid}/{slug}.
+# CloudFront honors s-maxage; the warmer + per-game push invalidation keep it fresh.
+_GAME_PAGE_CACHE_CONTROL = "s-maxage=86400, stale-while-revalidate=604800"
+```
+
+With:
+
+```python
+# Edge-cache header for the four SSR-fanout endpoints feeding /games/{appid}/{slug}.
+# 7d s-maxage is safe: revalidate_frontend issues a CloudFront invalidation
+# covering all four /api/games/{appid}/* paths whenever an analysis completes.
+# SWR=30d so a cache expiry never blocks a visitor on a Lambda cold start.
+_GAME_PAGE_CACHE_CONTROL = "s-maxage=604800, stale-while-revalidate=2592000"
+```
+
+That is the only edit.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/lambda-functions/lambda_functions/api/handler.py` | Bump `_GAME_PAGE_CACHE_CONTROL` from 24h/7d to 7d/30d; refresh comment |
+
+## Out of Scope (per prompt)
+
+- HTML page cache headers in `frontend/app/games/[appid]/[slug]/page.tsx`.
+- Other cache constants in the same file (`_NEW_RELEASES_CACHE`, `_DISCOVERY_CACHE`, `_REPORTS_CACHE`, `_HOME_INTEL_CACHE`).
+- CloudFront `api_cache_policy` in `infra/stacks/delivery_stack.py` (already `max_ttl=365d`).
+- OpenNext incremental cache wiring in `compute_stack.py`.
+- `scripts/warm_game_pages.py` scheduling / multi-POP coverage.
+- Unit tests for the constant (per `feedback_no_script_tests.md` and explicit prompt instruction).
+- No commits, no pushes, no deploys (operator handles those, per `feedback_no_commit_push.md` and `feedback_no_deploy.md`).
+
+## Verification (operator runs after deploy)
+
+1. `curl -sI 'https://d1mamturmn55fm.cloudfront.net/api/games/3265700/report' | grep -iE 'cache-control|x-cache|age'` should report `cache-control: s-maxage=604800, stale-while-revalidate=2592000`.
+2. Loop over the four endpoints (`report`, `review-stats`, `benchmarks`, `related-analyzed`) and confirm second hit returns `x-cache: Hit from cloudfront`.
+3. Trigger a re-analysis for a cached game; after the analysis-complete event, re-curl should show `x-cache: Miss from cloudfront, age: 0` (pipeline invalidation still wins).
+4. `aws cloudfront list-invalidations` should still show the four `/api/games/{appid}/*` paths in the most-recent batch.
+
+## Critical References
+
+- `src/lambda-functions/lambda_functions/api/handler.py:54-56` (the constant)
+- `src/lambda-functions/lambda_functions/api/handler.py:364, 374, 403, 516` (the four endpoints emitting it)
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py:120-143` (push invalidation that makes the longer TTL safe)
+- `infra/stacks/delivery_stack.py:99-116, 198-201` (CloudFront cache policy + behavior routing — untouched)

--- a/scripts/prompts/game-page-canonical-slug-redirect.md
+++ b/scripts/prompts/game-page-canonical-slug-redirect.md
@@ -1,0 +1,172 @@
+# game-page-canonical-slug-redirect
+
+Make `/games/{appid}/{slug}` 308-redirect to the canonical slug when the URL slug doesn't match what the API considers the slug-of-record. Today the page renders any slug that arrives, and the canonical tag echoes whatever was in the URL, so two URLs for the same game can index simultaneously and dilute link equity.
+
+## Why
+
+Production verification (2026-04-30) on `d1mamturmn55fm.cloudfront.net`:
+
+```
+GET /api/games/3265700/report → "slug":"vampire-crawlers-the-turbo-wildcard-from-vampire-survivors-3265700"
+GET /games/3265700/vampire-crawlers → 200 OK, page renders
+```
+
+The API knows the canonical slug. The page accepts the wrong one, renders happily, and the canonical tag at `frontend/app/games/[appid]/[slug]/page.tsx:21,192` is built from the URL slug rather than the API slug, so it points at the *wrong* URL. Same for the JSON-LD Article schema's `mainEntityOfPage` field at line 278.
+
+Search engines mostly honor canonical tags, but a server-side 308 redirect is stronger and more immediate than letting Google sort out conflicting URLs over weeks of crawls. It also kills the canonical-tag bug as a side effect, since the only slug that ever reaches the renderer is the canonical one. The sitemap (`frontend/app/sitemap.ts:61`) already emits canonical URLs (`game.slug`), so this just enforces what the sitemap already promises.
+
+Risk avoided: anyone sharing a stale-titled link (Steam title rename, partial slug, manual typo) currently produces a duplicate-content surface that competes with the canonical URL. Once the redirect is in place, every variant collapses to the one URL.
+
+## Goal
+
+After this prompt:
+- A request to `/games/{appid}/{wrong-slug}` returns `308 Permanent Redirect` to `/games/{appid}/{canonical-slug}` whenever `wrong-slug !== canonical-slug` and the API knows a canonical slug for that appid.
+- A request to the canonical URL renders the page, no redirect.
+- Unknown appids continue to 404 via the existing `notFound()` paths.
+- The `<link rel="canonical">` tag in both `generateMetadata` and the page render uses the API's canonical slug, not the URL slug. (Belt-and-suspenders: with the redirect in place this can only ever match the URL, but it's the right value to compute regardless.)
+- The JSON-LD Article schema's `mainEntityOfPage` and the `canonicalUrl` constant both reference the canonical URL.
+- No change to API responses, sitemap shape, or any other route.
+
+## Scope
+
+**In:**
+- `frontend/app/games/[appid]/[slug]/page.tsx`: add a slug check + `permanentRedirect()` after the API fetch in the page default export. Update `canonicalUrl` calculations in both `generateMetadata` and the page default export to use the API slug (with safe fallback to the URL slug when the API didn't return one, e.g. unknown appid edge cases).
+- A short comment explaining that the redirect is intentional and what it protects against.
+
+**Out:**
+- API changes. The API already returns `slug` in the response shape (`frontend/lib/api.ts:75`); no contract change needed.
+- Sitemap. Already emits canonical URLs.
+- Other dynamic routes (`/genre/[slug]`, `/tag/[slug]`, `/developer/[slug]`, `/publisher/[slug]`). Their slugs are themselves the canonical identifier; there's no separate canonical-of-record like games have (appid + slug). Out of scope; can be a follow-up if a similar mismatch surfaces.
+- Migrating any in-the-wild bad links. The redirect handles them automatically as soon as it ships.
+- Changing any redirect to a 301 vs 308. Next.js `permanentRedirect()` issues 308; Google treats 301 and 308 equivalently for permanent moves.
+- Adding a redirect from `/games/{appid}` (no slug) to the canonical URL. The route doesn't exist; would need a separate `/games/[appid]/page.tsx` if added. Out of scope.
+- Tests. The page is a Server Component; per project convention there are no unit tests for page-level redirect logic, and a Playwright check is a separate thread.
+- No commits, pushes, or deploys. Operator handles those.
+
+## Decisions
+
+1. **Why 308 (`permanentRedirect`) and not 307 (`redirect`)?** The canonical slug is durable for a given appid (changes only on Steam title rename, which is rare). 308 tells search engines and clients "this is the new home, update your records." 307 would invite re-crawling the wrong URL forever.
+
+2. **What if the API doesn't return a slug?** Fall back to the URL slug for the canonical tag calculation; do NOT redirect. Keeps the existing behavior for edge cases (unknown appid that still returns minimal `game_meta`, or transient API hiccup mid-render). The redirect should only fire when the API confidently returns a different canonical slug.
+
+3. **Why not also redirect when the slug case differs?** The slugify step (`frontend/lib/format.ts:40`) already lowercases, so a mixed-case URL would normalize to the same string for comparison. If we ever introduced case-sensitive divergence, the equality check would still catch it. Not a real concern today.
+
+4. **`generateMetadata` redirect?** Next.js documents `redirect()` as callable from `generateMetadata`, but the page default export runs in parallel and will issue the same redirect anyway. Doing it in one place (the default export) is simpler and avoids a duplicate fetch path; the metadata function just needs to compute the canonical URL correctly using the API slug it already fetches.
+
+## Changes
+
+### 1. `frontend/app/games/[appid]/[slug]/page.tsx`
+
+Add the import:
+
+```typescript
+import { notFound, permanentRedirect } from "next/navigation";
+```
+
+In the default export `GameReportPage`, after the `Promise.all` fetch and before any rendering, add the redirect check (right after the existing `if (reportData.game) { ... }` block where `g` is destructured):
+
+```typescript
+// Slug is canonicalized to whatever the API returns. Wrong/stale slugs
+// 308 to the canonical URL so search engines see one URL per game.
+const canonicalSlug = reportData.game?.slug;
+if (canonicalSlug && canonicalSlug !== slug) {
+  permanentRedirect(`/games/${appid}/${canonicalSlug}`);
+}
+```
+
+Then update both `canonicalUrl` constants to prefer the API slug, with the URL slug as the fallback for the unknown-appid edge case:
+
+```typescript
+// generateMetadata (around line 21):
+const reportData = await getGameReport(numericAppid);
+const effectiveSlug = reportData.game?.slug ?? slug;
+const canonicalUrl = `https://steampulse.io/games/${appid}/${effectiveSlug}`;
+// ...rest unchanged
+
+// Default export (around line 192):
+const effectiveSlug = reportData?.game?.slug ?? slug;
+const canonicalUrl = `https://steampulse.io/games/${appid}/${effectiveSlug}`;
+```
+
+Note: in `generateMetadata`, the existing code already calls `getGameReport` and stores the result as `reportData`; reuse it. In the default export, after the redirect check above, `reportData.game.slug` always equals the URL slug (because we'd have redirected otherwise), so `effectiveSlug` is just defensive.
+
+### 2. (Optional consistency) Update Article JSON-LD's `mainEntityOfPage`
+
+The Article schema at line 278 already uses `canonicalUrl`, so once the constant is fixed it's automatically right. No further change needed.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `frontend/app/games/[appid]/[slug]/page.tsx` | Import `permanentRedirect`; redirect on slug mismatch in default export; use API slug in `canonicalUrl` for both `generateMetadata` and the default export |
+
+## Verification
+
+After deploy (operator runs the deploy):
+
+1. **Wrong slug 308s to canonical:**
+   ```bash
+   curl -sI 'https://d1mamturmn55fm.cloudfront.net/games/3265700/wrong-slug' \
+     | grep -iE 'http|location'
+   ```
+   Expect `HTTP/2 308` and `location: /games/3265700/vampire-crawlers-the-turbo-wildcard-from-vampire-survivors-3265700`.
+
+2. **Canonical slug renders 200, no redirect:**
+   ```bash
+   curl -sI 'https://d1mamturmn55fm.cloudfront.net/games/3265700/vampire-crawlers-the-turbo-wildcard-from-vampire-survivors-3265700' \
+     | grep -iE 'http|x-cache'
+   ```
+   Expect `HTTP/2 200`.
+
+3. **Canonical tag points at the canonical URL** (use a wrong slug to prove the redirect-then-render produces the right tag):
+   ```bash
+   curl -sL 'https://d1mamturmn55fm.cloudfront.net/games/3265700/wrong-slug' \
+     | grep -oE '<link rel="canonical"[^>]*>' | head -1
+   ```
+   Expect the `href` to be the canonical URL, not `/games/3265700/wrong-slug`.
+
+4. **Unknown appid still 404s:**
+   ```bash
+   curl -sI 'https://d1mamturmn55fm.cloudfront.net/games/999999999/anything' \
+     | grep -iE 'http'
+   ```
+   Expect `HTTP/2 404`.
+
+5. **Sitemap URLs all render 200 without redirect** (sample 5):
+   ```bash
+   curl -s https://d1mamturmn55fm.cloudfront.net/sitemap.xml \
+     | grep -oE '<loc>https://[^<]+/games/[0-9]+/[^<]+</loc>' \
+     | head -5 \
+     | sed -E 's|.*<loc>https?://[^/]+(.*)</loc>|\1|' \
+     | while read path; do
+         echo -n "$path → "
+         curl -sI "https://d1mamturmn55fm.cloudfront.net$path" | head -1
+       done
+   ```
+   Every line should show `HTTP/2 200`. If any 308, the sitemap is emitting non-canonical URLs and there's a slug-generation bug separate from this fix.
+
+6. **Search Console** (post-deploy, lagging signal): the "Duplicate without user-selected canonical" report should trend down over the next few crawls.
+
+## What NOT To Do
+
+- Do NOT use `redirect()` (307); use `permanentRedirect()` (308) so search engines update their index instead of re-crawling the wrong URL.
+- Do NOT redirect in `generateMetadata`. The page default export's redirect runs anyway; doing it twice just risks a subtle race.
+- Do NOT redirect when the API didn't return a slug (e.g. minimal-metadata fallback for unknown appid). Falls back to URL slug + canonical tag, same as today's behavior.
+- Do NOT change the API contract. `slug` is already in the response.
+- Do NOT touch `/genre`, `/tag`, `/developer`, `/publisher` routes in this prompt; those slugs are the canonical identifier themselves and don't have an appid-vs-slug split.
+- Do NOT add a feature flag or env-var gate; pre-launch project, just ship the fix.
+- Do NOT shorten or alter the page-level `revalidate = 31536000`. Redirects bypass ISR (Next.js evaluates the redirect at request time before serving the cached page), so the 1y page cache stays correct.
+- Do NOT add a separate redirect for `/games/{appid}` (no slug); that route doesn't exist and creating it is a different prompt.
+
+## Existing Code Reference
+
+- `frontend/app/games/[appid]/[slug]/page.tsx:18` is where URL params are unpacked
+- `frontend/app/games/[appid]/[slug]/page.tsx:21,192` is the `canonicalUrl` constants that need to use the API slug
+- `frontend/app/games/[appid]/[slug]/page.tsx:24,130` is where `getGameReport` is called and `reportData.game.slug` becomes available
+- `frontend/app/games/[appid]/[slug]/page.tsx:86,182` is the existing `notFound()` paths for unknown appids (untouched)
+- `frontend/app/games/[appid]/[slug]/page.tsx:278` is the Article JSON-LD `mainEntityOfPage` (already references `canonicalUrl`, fixed transitively)
+- `frontend/lib/api.ts:75` is the response-shape `slug?: string` field returned by `getGameReport`
+- `frontend/app/sitemap.ts:61` is where the sitemap emits canonical URLs (`game.slug`); enforces this fix's contract
+- `src/lambda-functions/lambda_functions/api/handler.py:289` is where the API serves `game.slug` in the report response
+- `src/library-layer/library_layer/services/crawl_service.py:365` is where `slugify(name, appid)` produces the canonical slug at crawl time
+- Next.js `permanentRedirect` docs: https://nextjs.org/docs/app/api-reference/functions/permanentRedirect (issues 308)

--- a/scripts/prompts/revalidate-frontend-discover-inner-build-id.md
+++ b/scripts/prompts/revalidate-frontend-discover-inner-build-id.md
@@ -1,0 +1,210 @@
+# revalidate-frontend-discover-inner-build-id
+
+Fix the silent OpenNext page-cache delete bug in `revalidate_frontend`. After every analysis, the Lambda issues an S3 `delete_objects` against a key that does not exist, so the stale page-cache file lingers and CloudFront re-caches stale HTML on the very next request. The pipeline appears to work end-to-end (Lambda logs "Revalidated", invalidation completes) but visitors keep seeing the pre-analysis page.
+
+## Why
+
+OpenNext writes page-cache files under `cache/{OUTER}/{INNER}/games/{appid}/{slug}.cache`. The Lambda assumes `OUTER == INNER` ("the inner BUILD_ID matches after pinning", per the comment at `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py:53-54`). In the live production deploy they do not match.
+
+Reproduced 2026-04-30 for appid 3265700 (vampire-crawlers):
+
+```
+$ aws lambda get-function-configuration ... | jq .Environment.Variables.CACHE_BUCKET_KEY_PREFIX
+"cache/b5e1077/"
+
+$ aws s3 ls --recursive s3://steampulse-frontend-production/cache/b5e1077/ | grep 3265700
+2026-04-30 15:31:57   cache/b5e1077/2b12bbe/games/3265700/vampire-crawlers-the-turbo-wildcard-from-vampire-survivors-3265700.cache
+2026-04-30 15:42:52   cache/b5e1077/2b12bbe/games/3265700/vampire-crawlers.cache
+```
+
+The Lambda computes the delete key as `cache/b5e1077/b5e1077/games/3265700/...cache` (built from `_CACHE_KEY_PREFIX + _BUILD_ID + ...`), which does not exist. `delete_objects` returns success for missing keys, no S3 `Errors` are surfaced, the Lambda logs "Revalidated", and the actual stale file at `cache/b5e1077/2b12bbe/...` is never touched.
+
+End-to-end consequence after the latest analysis (synthesis 21:56:45, revalidate-frontend "Revalidated" 21:57:10, CloudFront invalidation `IA25K7BS2J2VIF7TDFFA7BZQXH` Completed):
+- `/api/games/3265700/report` returns the fresh JSON (one_liner "A dangerously addictive first-person deckbuilder…").
+- `/games/3265700/...` HTML returns `x-nextjs-cache: STALE`, `x-cache: Hit from cloudfront`, with the pre-analysis Steam description.
+- The stale file's mtime (15:31) is from a prior render; OpenNext re-served it because the delete missed.
+
+This affects every game re-analyzed since the OUTER/INNER build IDs diverged — not just vampire-crawlers.
+
+## Goal
+
+After this prompt:
+- `revalidate_frontend` discovers the inner build ID(s) at module load by listing `cache/{OUTER}/` with `Delimiter="/"` and using the returned `CommonPrefixes`.
+- `_delete_page_cache` deletes `.cache` and `.cache.meta` keys under **every** discovered inner build ID, so the same Lambda is correct whether the build IDs match (future) or diverge (today).
+- Cold start raises loudly if no inner build IDs are found, so a misconfigured deploy can't silently fail again.
+- A short comment update so the next reader understands the OUTER/INNER distinction.
+
+## Scope
+
+**In:**
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py`: replace the static `_BUILD_ID` parsing with a dynamic discovery, update `_delete_page_cache` to iterate, refresh the comment.
+- Update `tests/lambda_functions/revalidate_frontend/test_handler.py` (or wherever the existing tests live) so the new discovery + multi-inner-id delete is covered.
+
+**Out:**
+- The `_post_revalidate` flow (POST to `/api/revalidate`). Already correct.
+- The CloudFront invalidation (`_invalidate_cdn`). Already correct.
+- The `ReportReadyEvent` publish path in `analysis/handler.py` and `batch_analysis/collect_phase.py`. Already correct.
+- The OpenNext build itself. Pinning OUTER == INNER would also fix this, but it's a deeper change in the frontend build pipeline and is brittle to future regressions; making the Lambda tolerate the divergence is the durable fix.
+- One-time cleanup of stale `.cache` files for previously-broken games. Out of scope here; tracked separately under "Fix-forward cleanup" below.
+- No commits, pushes, or deploys. Operator handles those.
+
+## Decisions
+
+1. **Discover at cold start, not per-invocation.** One ListObjectsV2 at module load, cached for the life of the Lambda container. Inner build IDs only change on a new frontend deploy, which replaces the container anyway.
+
+2. **Iterate over all inner IDs, not just the latest.** Cheap defense against a build that leaves multiple inner directories sitting in the bucket (e.g., a partial deploy). Each delete batch is at most ~`2 * len(_INNER_BUILD_IDS)` keys; in practice that's 2 to 4 keys per call.
+
+3. **Fail cold start if zero inner IDs are found.** Same posture as the existing `_require_param`: better to crash visibly than to silently no-op forever.
+
+4. **Keep `_parse_cache_key_prefix` for format validation, but stop returning the inner ID.** The function's value now is "fail fast on a malformed env var", not "give us the inner ID".
+
+5. **No feature flag.** Pre-launch project; just ship the new path forward (per `feedback_no_pre_launch_flags.md`).
+
+## Changes
+
+### 1. `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py`
+
+Replace the current `_parse_cache_key_prefix` + `_CACHE_KEY_PREFIX, _BUILD_ID = ...` block (lines 43-55) with:
+
+```python
+def _validate_cache_key_prefix(prefix: str) -> str:
+    """Fail loud if CACHE_BUCKET_KEY_PREFIX is malformed."""
+    if not prefix.startswith("cache/") or not prefix.endswith("/"):
+        raise ValueError(f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}")
+    outer = prefix[len("cache/") : -1]
+    if not outer or "/" in outer:
+        raise ValueError(f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}")
+    return prefix
+
+
+_CACHE_KEY_PREFIX = _validate_cache_key_prefix(os.environ["CACHE_BUCKET_KEY_PREFIX"])
+_HTTP_TIMEOUT_SECONDS = 5.0
+_s3 = boto3.client("s3")
+_cloudfront = boto3.client("cloudfront")
+
+
+def _discover_inner_build_ids() -> list[str]:
+    """List subdirs of cache/{OUTER}/ to find OpenNext's inner build ID(s)."""
+    response = _s3.list_objects_v2(
+        Bucket=_FRONTEND_BUCKET,
+        Prefix=_CACHE_KEY_PREFIX,
+        Delimiter="/",
+    )
+    common = response.get("CommonPrefixes") or []
+    inner_ids = [p["Prefix"][len(_CACHE_KEY_PREFIX) : -1] for p in common]
+    inner_ids = [i for i in inner_ids if i]
+    if not inner_ids:
+        raise RuntimeError(
+            f"No inner build IDs found under s3://{_FRONTEND_BUCKET}/{_CACHE_KEY_PREFIX} "
+            "— frontend deploy may be incomplete."
+        )
+    return inner_ids
+
+
+# OpenNext writes pages to cache/{OUTER}/{INNER}/... where OUTER comes from
+# CACHE_BUCKET_KEY_PREFIX and INNER is OpenNext's own build id; the two do
+# not always match, so discover INNER from S3 instead of assuming.
+_INNER_BUILD_IDS = _discover_inner_build_ids()
+```
+
+Replace `_delete_page_cache` (lines 97-117) with:
+
+```python
+def _delete_page_cache(appid: int, slug: str) -> None:
+    """Delete OpenNext S3 page-cache files for this game across all inner build IDs.
+
+    Required workaround: OpenNext doesn't tag dynamic-route page entries
+    in DynamoDB, so revalidatePath/revalidateTag don't bust them.
+    """
+    objects = []
+    for inner in _INNER_BUILD_IDS:
+        base = f"{_CACHE_KEY_PREFIX}{inner}/games/{appid}/{slug}"
+        objects.append({"Key": f"{base}.cache"})
+        objects.append({"Key": f"{base}.cache.meta"})
+    response = _s3.delete_objects(
+        Bucket=_FRONTEND_BUCKET,
+        Delete={"Objects": objects},
+    )
+    errors = response.get("Errors") or []
+    if errors:
+        raise RuntimeError(f"S3 delete_objects errors: {errors}")
+```
+
+### 2. Tests
+
+Update the existing `revalidate_frontend` tests:
+
+- Replace any test that asserted `_BUILD_ID` parsing with one that mocks `s3.list_objects_v2` to return `CommonPrefixes` and asserts `_INNER_BUILD_IDS` is populated.
+- Add a test that calls `_delete_page_cache` with two mocked inner IDs and asserts the resulting `delete_objects` call lists 4 keys (`.cache` and `.cache.meta` for each inner ID).
+- Add a test that mocks `list_objects_v2` returning empty `CommonPrefixes` and asserts module import / `_discover_inner_build_ids` raises `RuntimeError`.
+
+Per `feedback_test_db.md` this Lambda has no DB dependency, so no DB fixture work needed. Per `feedback_no_script_tests.md` only the Lambda code is tested, not operator scripts.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py` | Discover inner build IDs from S3 at cold start; iterate them in `_delete_page_cache`; rename `_parse_cache_key_prefix` to `_validate_cache_key_prefix`; refresh comment |
+| `tests/.../test_revalidate_frontend.py` (path TBD by implementer) | Cover the new discovery + multi-inner-id delete; replace any `_BUILD_ID`-coupled assertions |
+
+## Verification
+
+After deploy (operator runs the deploy):
+
+1. **Confirm the Lambda still cold-starts cleanly.** Trigger a synthetic invocation (or wait for the next analysis) and check the log group for the cold-start INIT_START. No `RuntimeError` from `_discover_inner_build_ids`.
+
+2. **Pick a game with a known stale page** (vampire-crawlers, appid 3265700 today) and re-trigger revalidation. Easiest path: re-publish a synthetic `ReportReadyEvent` to the SQS queue, or re-run the analysis pipeline for that appid.
+
+3. **Confirm the S3 stale file was actually deleted:**
+   ```bash
+   aws s3 ls "s3://steampulse-frontend-production/cache/b5e1077/2b12bbe/games/3265700/"
+   ```
+   Both `.cache` and `.cache.meta` for the long slug should be gone.
+
+4. **Confirm the page now serves fresh content:**
+   ```bash
+   curl -sI 'https://d1mamturmn55fm.cloudfront.net/games/3265700/vampire-crawlers-the-turbo-wildcard-from-vampire-survivors-3265700' \
+     | grep -iE 'x-cache|x-nextjs-cache|cache-control'
+   curl -s 'https://d1mamturmn55fm.cloudfront.net/games/3265700/vampire-crawlers-the-turbo-wildcard-from-vampire-survivors-3265700' \
+     | grep -c 'dangerously addictive'
+   ```
+   Expect: first request `x-cache: Miss from cloudfront`, `x-nextjs-cache: HIT` (fresh render); the grep should return at least 1 (the new one_liner is in the SSR output).
+
+5. **Confirm the API path is unaffected** (sanity, since this prompt does not touch it):
+   ```bash
+   curl -s 'https://d1mamturmn55fm.cloudfront.net/api/games/3265700/report' | head -c 300
+   ```
+
+## Fix-forward cleanup (operator, separate from the code change)
+
+Pages already cached under the wrong-inner-id path will keep serving stale HTML until they're either re-rendered or the stale `.cache` file is removed. Two ways to flush:
+
+- **Targeted (one game):** delete the stale `.cache`/`.cache.meta` and invalidate `/games/{appid}/*` in CloudFront. Same commands as in the previous chat session.
+- **Bulk (everything under the divergent inner ID):**
+  ```bash
+  aws s3 rm --recursive s3://steampulse-frontend-production/cache/b5e1077/2b12bbe/games/
+  aws cloudfront create-invalidation --distribution-id E38HJSG1GLX042 --paths '/games/*'
+  ```
+  Next.js will re-render each page on demand. Safe (no data loss) but cold-renders the next visitor for each page.
+
+The fixed Lambda will keep things correct from the next deploy onward, so this cleanup is only needed once.
+
+## What NOT To Do
+
+- Do NOT pin OPENNEXT_BUILD_ID = git SHA in the frontend build to make OUTER == INNER. It's a different layer and the Lambda fix is more robust (the assumption being violated is the bug; encoding the inverse assumption elsewhere is brittle).
+- Do NOT cache `_INNER_BUILD_IDS` to disk or DynamoDB. Module-level cache for the container's lifetime is sufficient and self-healing across deploys.
+- Do NOT add a feature flag, env-var override, or "fall back to the old key shape if discovery fails". Either discovery works (then we use it) or it doesn't (then we crash visibly).
+- Do NOT widen the prefix-listing call to recurse the whole bucket. Top-level `Delimiter="/"` is fast; a recursive list of `cache/` would scan every page-cache file.
+- Do NOT silence the `RuntimeError` on empty `CommonPrefixes`. That's the alarm telling us the deploy is broken.
+- Do NOT touch `_post_revalidate`, `_invalidate_cdn`, or the SNS/SQS wiring. Confirmed working end-to-end on 2026-04-30.
+- Do NOT bundle the bulk S3 cleanup into the Lambda code change. One-shot operator action; keep the Lambda PR focused.
+
+## Existing Code Reference
+
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py:43-55` — current `_parse_cache_key_prefix` + `_BUILD_ID` (the broken assumption)
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py:97-117` — `_delete_page_cache` (the no-op delete)
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py:120-143` — `_invalidate_cdn` (correct, untouched)
+- `src/lambda-functions/lambda_functions/revalidate_frontend/handler.py:146-177` — handler (correct, untouched)
+- `src/lambda-functions/lambda_functions/batch_analysis/collect_phase.py:566-578` — where `ReportReadyEvent` is published from the batch path (correct, untouched)
+- `src/lambda-functions/lambda_functions/analysis/handler.py:145-157` — where `ReportReadyEvent` is published from the per-game path (correct, untouched)
+- `infra/stacks/compute_stack.py:1042-1043` — where `REVALIDATE_TOKEN_PARAM` and `DISTRIBUTION_ID_PARAM` env vars are wired (untouched, but useful context for `CACHE_BUCKET_KEY_PREFIX` provenance)

--- a/src/lambda-functions/lambda_functions/api/handler.py
+++ b/src/lambda-functions/lambda_functions/api/handler.py
@@ -52,8 +52,10 @@ _sqs_client = boto3.client("sqs")
 VERSION = "0.1.0"
 
 # Edge-cache header for the four SSR-fanout endpoints feeding /games/{appid}/{slug}.
-# CloudFront honors s-maxage; the warmer + per-game push invalidation keep it fresh.
-_GAME_PAGE_CACHE_CONTROL = "s-maxage=86400, stale-while-revalidate=604800"
+# 7d s-maxage is safe: revalidate_frontend issues a CloudFront invalidation
+# covering all four /api/games/{appid}/* paths whenever an analysis completes.
+# SWR=30d so a cache expiry never blocks a visitor on a Lambda cold start.
+_GAME_PAGE_CACHE_CONTROL = "s-maxage=604800, stale-while-revalidate=2592000"
 
 # ---------------------------------------------------------------------------
 # Repository wiring — built once at module level.

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -143,8 +143,7 @@ def _invalidate_cdn(records: list[tuple[str, int]]) -> None:
     paths: set[str] = set()
     for _, appid in records:
         paths.add(f"/games/{appid}/*")
-        # API paths are edge-cached (s-maxage=86400) — must invalidate alongside HTML
-        # or fresh analyses serve stale data for up to 24 h.
+        # API paths are edge-cached too; invalidate alongside HTML or fresh analyses serve stale.
         paths.add(f"/api/games/{appid}/report")
         paths.add(f"/api/games/{appid}/review-stats")
         paths.add(f"/api/games/{appid}/benchmarks")

--- a/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
+++ b/src/lambda-functions/lambda_functions/revalidate_frontend/handler.py
@@ -40,22 +40,44 @@ _DISTRIBUTION_ID: str = _require_param(
 _FRONTEND_BUCKET: str = os.environ["FRONTEND_BUCKET"]
 
 
-def _parse_cache_key_prefix(prefix: str) -> tuple[str, str]:
-    """Validate "cache/{BUILD_ID}/" and return (prefix, build_id)."""
+def _validate_cache_key_prefix(prefix: str) -> str:
+    """Fail loud if CACHE_BUCKET_KEY_PREFIX is malformed."""
     if not prefix.startswith("cache/") or not prefix.endswith("/"):
         raise ValueError(f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}")
-    build_id = prefix[len("cache/") : -1]
-    if not build_id or "/" in build_id:
+    outer = prefix[len("cache/") : -1]
+    if not outer or "/" in outer:
         raise ValueError(f"CACHE_BUCKET_KEY_PREFIX must match 'cache/{{BUILD_ID}}/': {prefix!r}")
-    return prefix, build_id
+    return prefix
 
 
-# OpenNext writes pages under cache/{BUILD_ID}/{BUILD_ID}/... — the prefix
-# is "cache/{BUILD_ID}/" and the inner BUILD_ID matches after pinning.
-_CACHE_KEY_PREFIX, _BUILD_ID = _parse_cache_key_prefix(os.environ["CACHE_BUCKET_KEY_PREFIX"])
+_CACHE_KEY_PREFIX = _validate_cache_key_prefix(os.environ["CACHE_BUCKET_KEY_PREFIX"])
 _HTTP_TIMEOUT_SECONDS = 5.0
 _s3 = boto3.client("s3")
 _cloudfront = boto3.client("cloudfront")
+
+
+def _discover_inner_build_ids() -> list[str]:
+    """List subdirs of cache/{OUTER}/ to find OpenNext's inner build ID(s)."""
+    response = _s3.list_objects_v2(
+        Bucket=_FRONTEND_BUCKET,
+        Prefix=_CACHE_KEY_PREFIX,
+        Delimiter="/",
+    )
+    common = response.get("CommonPrefixes") or []
+    inner_ids = [p["Prefix"][len(_CACHE_KEY_PREFIX) : -1] for p in common]
+    inner_ids = [i for i in inner_ids if i]
+    if not inner_ids:
+        raise RuntimeError(
+            f"No inner build IDs found under s3://{_FRONTEND_BUCKET}/{_CACHE_KEY_PREFIX} "
+            "frontend deploy may be incomplete."
+        )
+    return inner_ids
+
+
+# OpenNext writes pages to cache/{OUTER}/{INNER}/... where OUTER comes from
+# CACHE_BUCKET_KEY_PREFIX and INNER is OpenNext's own build id; the two do
+# not always match, so discover INNER from S3 instead of assuming.
+_INNER_BUILD_IDS = _discover_inner_build_ids()
 
 # Lazy-init so connections pool across records and warm invocations.
 _http_client: httpx.Client | None = None
@@ -95,20 +117,19 @@ def _post_revalidate(appid: int, slug: str) -> None:
 
 
 def _delete_page_cache(appid: int, slug: str) -> None:
-    """Delete the OpenNext S3 page cache file (and .meta) for this game.
+    """Delete OpenNext S3 page-cache files for this game across all inner build IDs.
 
     Required workaround: OpenNext doesn't tag dynamic-route page entries
     in DynamoDB, so revalidatePath/revalidateTag don't bust them.
     """
-    base_key = f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/games/{appid}/{slug}"
+    objects: list[dict[str, str]] = []
+    for inner in _INNER_BUILD_IDS:
+        base = f"{_CACHE_KEY_PREFIX}{inner}/games/{appid}/{slug}"
+        objects.append({"Key": f"{base}.cache"})
+        objects.append({"Key": f"{base}.cache.meta"})
     response = _s3.delete_objects(
         Bucket=_FRONTEND_BUCKET,
-        Delete={
-            "Objects": [
-                {"Key": f"{base_key}.cache"},
-                {"Key": f"{base_key}.cache.meta"},
-            ]
-        },
+        Delete={"Objects": objects},
     )
     # delete_objects returns 200 even when individual keys fail (e.g.,
     # AccessDenied). Surface those so SQS retries / DLQ catches them.

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -56,6 +56,13 @@ def _seed_ssm_and_bucket() -> None:
     )
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=_FRONTEND_BUCKET)
+    # Materialize the cache/{OUTER}/{INNER}/ CommonPrefix so the module-load
+    # _discover_inner_build_ids() call finds the inner build id at import time.
+    s3.put_object(
+        Bucket=_FRONTEND_BUCKET,
+        Key=f"{_CACHE_KEY_PREFIX}{_BUILD_ID}/_init",
+        Body=b"",
+    )
 
 
 def _stub_cloudfront(handler: Any) -> list[dict]:
@@ -568,3 +575,56 @@ def test_no_records_skips_cloudfront_call(httpx_mock: HTTPXMock) -> None:
     assert result == {"batchItemFailures": []}
     assert captured == []
     assert httpx_mock.get_requests() == []
+
+
+@mock_aws
+def test_module_load_discovers_inner_build_id() -> None:
+    """Cold start lists cache/{OUTER}/ and populates _INNER_BUILD_IDS from CommonPrefixes."""
+    handler, _ = _get_module()
+    assert handler._INNER_BUILD_IDS == [_BUILD_ID]
+
+
+@mock_aws
+def test_delete_page_cache_iterates_all_inner_build_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When multiple inner ids are discovered, delete fires .cache + .cache.meta for each."""
+    handler, _ = _get_module()
+    monkeypatch.setattr(handler, "_INNER_BUILD_IDS", ["inner-a", "inner-b"])
+
+    captured_kwargs: list[dict] = []
+
+    def _capture(**kwargs: Any) -> dict:
+        captured_kwargs.append(kwargs)
+        return {"Deleted": [{"Key": o["Key"]} for o in kwargs["Delete"]["Objects"]]}
+
+    monkeypatch.setattr(handler._s3, "delete_objects", _capture)
+
+    handler._delete_page_cache(42, "demo-slug")
+
+    assert len(captured_kwargs) == 1
+    keys = [o["Key"] for o in captured_kwargs[0]["Delete"]["Objects"]]
+    assert keys == [
+        f"{_CACHE_KEY_PREFIX}inner-a/games/42/demo-slug.cache",
+        f"{_CACHE_KEY_PREFIX}inner-a/games/42/demo-slug.cache.meta",
+        f"{_CACHE_KEY_PREFIX}inner-b/games/42/demo-slug.cache",
+        f"{_CACHE_KEY_PREFIX}inner-b/games/42/demo-slug.cache.meta",
+    ]
+
+
+@mock_aws
+def test_module_load_raises_when_no_inner_build_ids_found() -> None:
+    """Empty cache/{OUTER}/ prefix is a broken deploy — must crash loudly."""
+    import sys
+
+    ssm = boto3.client("ssm", region_name="us-east-1")
+    ssm.put_parameter(Name=_REVALIDATE_TOKEN_PARAM, Value=_TOKEN, Type="String", Overwrite=True)
+    ssm.put_parameter(
+        Name=_DISTRIBUTION_ID_PARAM, Value=_DISTRIBUTION_ID, Type="String", Overwrite=True
+    )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=_FRONTEND_BUCKET)
+    # Note: deliberately no inner-id placeholder object.
+    sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
+    with pytest.raises(RuntimeError, match="No inner build IDs found"):
+        import lambda_functions.revalidate_frontend.handler  # noqa: F401

--- a/tests/handlers/test_revalidate_frontend_handler.py
+++ b/tests/handlers/test_revalidate_frontend_handler.py
@@ -585,6 +585,51 @@ def test_module_load_discovers_inner_build_id() -> None:
 
 
 @mock_aws
+def test_module_load_discovers_divergent_inner_build_id_and_deletes_that_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production bug: INNER != OUTER. Discovery must surface the actual inner id."""
+    import sys
+
+    different_inner = "different-inner"
+
+    ssm = boto3.client("ssm", region_name="us-east-1")
+    ssm.put_parameter(Name=_REVALIDATE_TOKEN_PARAM, Value=_TOKEN, Type="String", Overwrite=True)
+    ssm.put_parameter(
+        Name=_DISTRIBUTION_ID_PARAM, Value=_DISTRIBUTION_ID, Type="String", Overwrite=True
+    )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=_FRONTEND_BUCKET)
+    s3.put_object(
+        Bucket=_FRONTEND_BUCKET,
+        Key=f"{_CACHE_KEY_PREFIX}{different_inner}/games/42/demo-slug.cache",
+        Body=b"seed",
+    )
+
+    sys.modules.pop("lambda_functions.revalidate_frontend.handler", None)
+    import lambda_functions.revalidate_frontend.handler as handler
+
+    assert handler._INNER_BUILD_IDS == [different_inner]
+
+    captured_kwargs: list[dict] = []
+
+    def _capture(**kwargs: Any) -> dict:
+        captured_kwargs.append(kwargs)
+        return {"Deleted": [{"Key": o["Key"]} for o in kwargs["Delete"]["Objects"]]}
+
+    monkeypatch.setattr(handler._s3, "delete_objects", _capture)
+
+    handler._delete_page_cache(42, "demo-slug")
+
+    assert len(captured_kwargs) == 1
+    keys = [o["Key"] for o in captured_kwargs[0]["Delete"]["Objects"]]
+    assert keys == [
+        f"{_CACHE_KEY_PREFIX}{different_inner}/games/42/demo-slug.cache",
+        f"{_CACHE_KEY_PREFIX}{different_inner}/games/42/demo-slug.cache.meta",
+    ]
+
+
+@mock_aws
 def test_delete_page_cache_iterates_all_inner_build_ids(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1128,7 +1128,7 @@ def test_home_intel_snapshot_source_exception_isolated(
 # Path matching selects the cached /api/games/*/{...} behavior; this header
 # tells CloudFront's html_cache_policy how long to cache the response (s-maxage)
 # and how long to serve stale-while-revalidate.
-_EXPECTED_CACHE_CONTROL = "s-maxage=86400, stale-while-revalidate=604800"
+_EXPECTED_CACHE_CONTROL = "s-maxage=604800, stale-while-revalidate=2592000"
 
 
 class _MemReportRepoWithRelated(_MemReportRepo):


### PR DESCRIPTION
Carefully check this PR!! It implements prompt at: scripts/prompts/revalidate-frontend-discover-inner-build-id.md.

Specific things to check:

- **`_discover_inner_build_ids` listing call** at module load uses `Prefix=_CACHE_KEY_PREFIX, Delimiter="/"` — verify the slicing in `inner_ids = [p["Prefix"][len(_CACHE_KEY_PREFIX) : -1] for p in common]` correctly trims both the outer prefix and the trailing `/` from each `CommonPrefix`.
- **Cold-start crash on empty `CommonPrefixes`** is intentional and load-bearing — confirm the `RuntimeError` is the right posture (vs. silent no-op) and that the message helps an operator diagnose a partial frontend deploy.
- **IAM** — the Lambda already calls `s3.delete_objects` on `_FRONTEND_BUCKET`; verify the existing role policy also allows `s3:ListBucket` on the same bucket so `list_objects_v2` succeeds. If not, the cold start will fail loudly (good signal) but ship needs the policy update first.
- **Multi-inner-id delete batch** in `_delete_page_cache`: each call now sends `2 * len(_INNER_BUILD_IDS)` keys. In production today that's 2 keys (one inner id) and tomorrow up to ~4 (after a fresh deploy leaves both ids briefly). Confirm we never approach the 1000-key `delete_objects` limit.
- **Test seed change**: `_seed_ssm_and_bucket` now puts a placeholder `cache/test-build/test-build/_init` object so the module-load discovery succeeds. Confirm this doesn't mask a real bug — the new `test_module_load_raises_when_no_inner_build_ids_found` covers the empty-bucket path explicitly.
- **Existing `test_module_load_rejects_malformed_cache_prefix`** still relies on `_validate_cache_key_prefix` raising `ValueError` *before* `_discover_inner_build_ids` runs. Confirm import-time ordering is preserved.
- **Drive-by fix in `tests/test_api.py:1131`** — `_EXPECTED_CACHE_CONTROL` updated from `s-maxage=86400, stale-while-revalidate=604800` to `s-maxage=604800, stale-while-revalidate=2592000` to match the implementation already on `main` (commit 7757a9d, `feature/api-cache-ttl-bump-plan`). The constant was missed in that earlier commit; full unit-test suite now ends 717 passed, 0 failed.
- **Out of scope (operator action)**: bulk cleanup of stale `.cache` files already cached under the divergent inner id (`cache/b5e1077/2b12bbe/games/`). The PR fixes the Lambda forward; existing stale entries need a one-shot `s3 rm --recursive` + CloudFront invalidation per the prompt's "Fix-forward cleanup" section.